### PR TITLE
Add searchable dropdown for loot checklist

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -199,6 +199,83 @@ button:hover {
   color: rgba(59, 73, 92, 0.6);
 }
 
+.loot-dropdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.loot-dropdown__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  border: 1px solid rgba(59, 73, 92, 0.2);
+  border-radius: 12px;
+  background: rgba(59, 73, 92, 0.08);
+  color: #3b495c;
+  font-weight: 700;
+  padding: 0.85rem 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.loot-dropdown__toggle:hover {
+  background: rgba(59, 73, 92, 0.12);
+  box-shadow: 0 8px 24px rgba(59, 73, 92, 0.12);
+}
+
+.loot-dropdown__label {
+  flex: 1;
+  text-align: left;
+}
+
+.loot-dropdown__count {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(59, 73, 92, 0.7);
+}
+
+.loot-dropdown__icon {
+  font-size: 0.75rem;
+  color: rgba(59, 73, 92, 0.7);
+}
+
+.loot-dropdown__panel {
+  border: 1px solid rgba(59, 73, 92, 0.2);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 18px 30px rgba(59, 73, 92, 0.12);
+}
+
+.loot-dropdown__search input {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(59, 73, 92, 0.25);
+  background: rgba(255, 255, 255, 0.9);
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.loot-dropdown__search input:focus {
+  outline: none;
+  border-color: #6b4f32;
+  box-shadow: 0 0 0 3px rgba(107, 79, 50, 0.15);
+}
+
+.loot-dropdown__list {
+  max-height: 360px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
 .loot-list {
   list-style: none;
   margin: 0;

--- a/frontend/src/components/LootChecklist.tsx
+++ b/frontend/src/components/LootChecklist.tsx
@@ -14,6 +14,8 @@ export function LootChecklist({ items, onCreate, onToggle, onDelete }: LootCheck
   const [form, setForm] = useState({ name: '', type: '', region: '', description: '' })
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [showCompleted, setShowCompleted] = useState(true)
+  const [isDropdownOpen, setIsDropdownOpen] = useState(true)
+  const [searchTerm, setSearchTerm] = useState('')
 
   const progress = useMemo(() => {
     if (!items.length) return 0
@@ -24,6 +26,41 @@ export function LootChecklist({ items, onCreate, onToggle, onDelete }: LootCheck
   const filteredItems = useMemo(() => {
     return items.filter((item) => (showCompleted ? true : !item.is_collected))
   }, [items, showCompleted])
+
+  const visibleItems = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase()
+    if (!query) {
+      return filteredItems
+    }
+
+    return filteredItems.filter((item) => {
+      const values = [item.name, item.type, item.region, item.description]
+        .filter((value): value is string => Boolean(value))
+        .map((value) => value.toLowerCase())
+
+      return values.some((value) => value.includes(query))
+    })
+  }, [filteredItems, searchTerm])
+
+  const hasQuery = Boolean(searchTerm.trim())
+  const displayCount = hasQuery ? visibleItems.length : filteredItems.length
+  const countLabel = displayCount > 1 || displayCount === 0 ? 'objets' : 'objet'
+
+  const emptyMessage = useMemo(() => {
+    if (!items.length) {
+      return 'Ajoutez des objectifs pour préparer vos expéditions.'
+    }
+    if (!filteredItems.length) {
+      return showCompleted ? 'Ajoutez des objectifs pour préparer vos expéditions.' : 'Tous les objets ont été récupérés.'
+    }
+    if (hasQuery && !visibleItems.length) {
+      return 'Aucun objet ne correspond à votre recherche.'
+    }
+    if (!visibleItems.length) {
+      return 'Ajoutez des objectifs pour préparer vos expéditions.'
+    }
+    return 'Ajoutez des objectifs pour préparer vos expéditions.'
+  }, [filteredItems.length, hasQuery, items.length, showCompleted, visibleItems.length])
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -109,25 +146,62 @@ export function LootChecklist({ items, onCreate, onToggle, onDelete }: LootCheck
           Ajouter à la liste
         </button>
       </form>
-      <ul className="loot-list">
-        {filteredItems.map((item) => (
-          <li key={item.id} className={item.is_collected ? 'loot-list__item loot-list__item--done' : 'loot-list__item'}>
-            <label>
-              <input type="checkbox" checked={item.is_collected} onChange={() => onToggle(item)} />
-              <span className="loot-list__name">{item.name}</span>
-            </label>
-            <div className="loot-list__details">
-              {item.type ? <span>{item.type}</span> : null}
-              {item.region ? <span>{item.region}</span> : null}
-              {item.description ? <span className="loot-list__description">{item.description}</span> : null}
+      <div className="loot-dropdown">
+        <button
+          type="button"
+          className="loot-dropdown__toggle"
+          aria-expanded={isDropdownOpen}
+          onClick={() => setIsDropdownOpen((state) => !state)}
+        >
+          <span className="loot-dropdown__label">Liste des objets à récupérer</span>
+          <span className="loot-dropdown__count">
+            {displayCount} {countLabel}
+          </span>
+          <span className="loot-dropdown__icon" aria-hidden="true">
+            {isDropdownOpen ? '▲' : '▼'}
+          </span>
+        </button>
+        {isDropdownOpen ? (
+          <div className="loot-dropdown__panel" role="region" aria-live="polite">
+            <div className="loot-dropdown__search">
+              <input
+                type="search"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Rechercher un objet, une région ou un type"
+                aria-label="Rechercher dans les objets à récupérer"
+              />
             </div>
-            <button className="link" onClick={() => onDelete(item)}>
-              Retirer
-            </button>
-          </li>
-        ))}
-        {!filteredItems.length ? <p className="empty">Ajoutez des objectifs pour préparer vos expéditions.</p> : null}
-      </ul>
+            {visibleItems.length ? (
+              <div className="loot-dropdown__list">
+                <ul className="loot-list">
+                  {visibleItems.map((item) => (
+                    <li
+                      key={item.id}
+                      className={item.is_collected ? 'loot-list__item loot-list__item--done' : 'loot-list__item'}
+                    >
+                      <label>
+                        <input type="checkbox" checked={item.is_collected} onChange={() => onToggle(item)} />
+                        <span className="loot-list__name">{item.name}</span>
+                      </label>
+                      <div className="loot-list__details">
+                        {item.type ? <span>{item.type}</span> : null}
+                        {item.region ? <span>{item.region}</span> : null}
+                        {item.description ? <span className="loot-list__description">{item.description}</span> : null}
+                      </div>
+                      <button className="link" onClick={() => onDelete(item)}>
+                        Retirer
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : (
+              <p className="empty">{emptyMessage}</p>
+            )}
+          </div>
+        ) : null}
+      </div>
     </Panel>
   )
 }


### PR DESCRIPTION
## Summary
- wrap the loot checklist in a collapsible dropdown with search to quickly filter objectives
- retain item interactions with improved empty state messaging and dynamic result count
- add styling for the dropdown panel, toggle button, and search field

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8662bcba4832b9d16163e5a9cca10