### PR TITLE
Make large data panels collapsible

### DIFF
--- a/frontend/src/components/ArmouryPanel.tsx
+++ b/frontend/src/components/ArmouryPanel.tsx
@@ -27,7 +27,7 @@ export function ArmouryPanel({ armours }: ArmouryPanelProps) {
   )
 
   return (
-    <Panel title="Armurerie" subtitle="Comparez rapidement les armures disponibles">
+    <Panel title="Armurerie" subtitle="Comparez rapidement les armures disponibles" collapsible>
       <div className="filters">
         <input
           type="search"

--- a/frontend/src/components/BestiaryPanel.tsx
+++ b/frontend/src/components/BestiaryPanel.tsx
@@ -95,6 +95,7 @@ export function BestiaryPanel({ enemies, onCreate, onUpdate, onDelete }: Bestiar
     <Panel
       title="Bestiaire"
       subtitle="Préparez-vous face aux menaces majeures"
+      collapsible
       actions={
         <input
           type="search"

--- a/frontend/src/components/Panel.tsx
+++ b/frontend/src/components/Panel.tsx
@@ -1,3 +1,4 @@
+import { useId, useState } from 'react'
 import type { PropsWithChildren, ReactNode } from 'react'
 import './panel.css'
 
@@ -6,19 +7,65 @@ interface PanelProps extends PropsWithChildren {
   subtitle?: string
   actions?: ReactNode
   className?: string
+  collapsible?: boolean
+  defaultCollapsed?: boolean
 }
 
-export function Panel({ title, subtitle, children, actions, className }: PanelProps) {
+export function Panel({
+  title,
+  subtitle,
+  children,
+  actions,
+  className,
+  collapsible = false,
+  defaultCollapsed = false,
+}: PanelProps) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed)
+  const bodyId = useId()
+
+  const showHeaderActions = Boolean(actions) || collapsible
+  const sectionClassName = ['panel', className, collapsed ? 'panel--collapsed' : undefined]
+    .filter(Boolean)
+    .join(' ')
+
+  function toggleCollapse() {
+    if (!collapsible) return
+    setCollapsed((previous) => !previous)
+  }
+
+  const toggleLabel = collapsed ? 'Déplier' : 'Replier'
+  const toggleIcon = collapsed ? '▸' : '▾'
+
   return (
-    <section className={`panel ${className ?? ''}`}>
+    <section className={sectionClassName}>
       <header className="panel__header">
         <div>
           <h2>{title}</h2>
           {subtitle ? <p className="panel__subtitle">{subtitle}</p> : null}
         </div>
-        {actions ? <div className="panel__actions">{actions}</div> : null}
+        {showHeaderActions ? (
+          <div className="panel__actions">
+            {collapsible ? (
+              <button
+                type="button"
+                className="panel__toggle"
+                onClick={toggleCollapse}
+                aria-expanded={!collapsed}
+                aria-controls={bodyId}
+              >
+                <span className="panel__toggle-icon" aria-hidden="true">
+                  {toggleIcon}
+                </span>
+                {toggleLabel}
+              </button>
+            ) : null}
+            {actions}
+          </div>
+        ) : null}
       </header>
-      <div className="panel__body">{children}</div>
+      <div className="panel__body" id={bodyId} hidden={collapsed}>
+        {children}
+      </div>
     </section>
   )
 }

--- a/frontend/src/components/SpellLibrary.tsx
+++ b/frontend/src/components/SpellLibrary.tsx
@@ -21,7 +21,7 @@ export function SpellLibrary({ spells }: SpellLibraryProps) {
   }, [spells, search, level])
 
   return (
-    <Panel title="Grimoire" subtitle="Consultez rapidement vos options arcaniques">
+    <Panel title="Grimoire" subtitle="Consultez rapidement vos options arcaniques" collapsible>
       <div className="filters">
         <input
           type="search"

--- a/frontend/src/components/panel.css
+++ b/frontend/src/components/panel.css
@@ -10,6 +10,10 @@
   backdrop-filter: blur(2px);
 }
 
+.panel--collapsed {
+  gap: 0.75rem;
+}
+
 .panel__header {
   display: flex;
   align-items: center;
@@ -41,10 +45,44 @@
   gap: 0.5rem;
 }
 
+.panel__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: none;
+  background: rgba(48, 62, 80, 0.12);
+  color: #2c3e50;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.panel__toggle:hover,
+.panel__toggle:focus-visible {
+  background: rgba(48, 62, 80, 0.22);
+}
+
+.panel__toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(44, 62, 80, 0.35);
+}
+
+.panel__toggle-icon {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
 .panel__body {
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
   font-size: 0.95rem;
   color: rgba(30, 34, 40, 0.9);
+}
+
+.panel--collapsed .panel__body {
+  display: none;
 }


### PR DESCRIPTION
## Summary
- add a collapsible toggle to the shared Panel component and hide panel bodies when closed
- enable the toggle on the armurerie, grimoire, and bestiaire panels to save screen space
- style the new header control so it matches the existing panel look and remains focus-visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c86b9319cc832b8c01af1bd1c8027b