### PR TITLE
Integrate React Query for data fetching

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.87.4",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -1343,6 +1344,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.87.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.87.4.tgz",
+      "integrity": "sha512-uNsg6zMxraEPDVO2Bn+F3/ctHi+Zsk+MMpcN8h6P7ozqD088F6mFY5TfGM7zuyIrL7HKpDyu6QHfLWiDxh3cuw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.87.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.87.4.tgz",
+      "integrity": "sha512-T5GT/1ZaNsUXf5I3RhcYuT17I4CPlbZgyLxc/ZGv7ciS6esytlbjb3DgUFO6c8JWYMDpdjSWInyGZUErgzqhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.87.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.87.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import './App.css'
 import { api } from './api'
-import type {
-  ArmourItem,
-  Build,
-  Enemy,
-  LootItem,
-  Race,
-  CharacterClass,
-  Spell,
-  WeaponItem,
-} from './types'
+import type { Build, Enemy, LootItem } from './types'
 import { ArmouryPanel } from './components/ArmouryPanel'
 import { BestiaryPanel } from './components/BestiaryPanel'
 import { BuildLibrary } from './components/BuildLibrary'
@@ -24,94 +16,122 @@ function sortByName<T extends { name: string }>(items: T[]): T[] {
 }
 
 function App() {
-  const [lootItems, setLootItems] = useState<LootItem[]>([])
-  const [builds, setBuilds] = useState<Build[]>([])
-  const [enemies, setEnemies] = useState<Enemy[]>([])
-  const [armours, setArmours] = useState<ArmourItem[]>([])
-  const [weapons, setWeapons] = useState<WeaponItem[]>([])
-  const [spells, setSpells] = useState<Spell[]>([])
-  const [races, setRaces] = useState<Race[]>([])
-  const [classes, setClasses] = useState<CharacterClass[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const queryClient = useQueryClient()
 
-  useEffect(() => {
-    async function load() {
-      try {
-        setIsLoading(true)
-        const [loot, buildData, enemyData, armourData, weaponData, spellData, raceData, classData] = await Promise.all([
-          api.getLootItems(),
-          api.getBuilds(),
-          api.getEnemies(),
-          api.getArmours(),
-          api.getWeapons(),
-          api.getSpells(),
-          api.getRaces(),
-          api.getClasses(),
-        ])
-        setLootItems(sortByName(loot))
-        setBuilds(sortByName(buildData))
-        setEnemies(sortByName(enemyData))
-        setArmours(sortByName(armourData))
-        setWeapons(sortByName(weaponData))
-        setSpells(sortByName(spellData))
-        setRaces(sortByName(raceData))
-        setClasses(sortByName(classData))
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Impossible de charger les données.'
-        setError(message)
-      } finally {
-        setIsLoading(false)
-      }
-    }
+  const lootQuery = useQuery({
+    queryKey: ['lootItems'],
+    queryFn: async () => sortByName(await api.getLootItems()),
+  })
+  const buildsQuery = useQuery({
+    queryKey: ['builds'],
+    queryFn: async () => sortByName(await api.getBuilds()),
+  })
+  const enemiesQuery = useQuery({
+    queryKey: ['enemies'],
+    queryFn: async () => sortByName(await api.getEnemies()),
+  })
+  const armoursQuery = useQuery({
+    queryKey: ['armours'],
+    queryFn: async () => sortByName(await api.getArmours()),
+  })
+  const weaponsQuery = useQuery({
+    queryKey: ['weapons'],
+    queryFn: async () => sortByName(await api.getWeapons()),
+  })
+  const spellsQuery = useQuery({
+    queryKey: ['spells'],
+    queryFn: async () => sortByName(await api.getSpells()),
+  })
+  const racesQuery = useQuery({
+    queryKey: ['races'],
+    queryFn: async () => sortByName(await api.getRaces()),
+  })
+  const classesQuery = useQuery({
+    queryKey: ['classes'],
+    queryFn: async () => sortByName(await api.getClasses()),
+  })
 
-    void load()
-  }, [])
+  const queries = [
+    lootQuery,
+    buildsQuery,
+    enemiesQuery,
+    armoursQuery,
+    weaponsQuery,
+    spellsQuery,
+    racesQuery,
+    classesQuery,
+  ] as const
+
+  const isLoading = queries.some((query) => query.isPending)
+  const firstError = queries.find((query) => query.error)?.error
+  const error =
+    firstError == null
+      ? null
+      : firstError instanceof Error
+        ? firstError.message
+        : 'Impossible de charger les données.'
 
   async function handleCreateLoot(payload: { name: string; type?: string; region?: string; description?: string }) {
     const created = await api.createLootItem({ ...payload, is_collected: false })
-    setLootItems((items) => sortByName([...items, created]))
+    queryClient.setQueryData<LootItem[]>(['lootItems'], (items = []) => sortByName([...items, created]))
   }
 
   async function handleToggleLoot(item: LootItem) {
     const updated = await api.updateLootItem(item.id, { is_collected: !item.is_collected })
-    setLootItems((items) => items.map((entry) => (entry.id === item.id ? updated : entry)))
+    queryClient.setQueryData<LootItem[]>(['lootItems'], (items = []) =>
+      sortByName(items.map((entry) => (entry.id === item.id ? updated : entry))),
+    )
   }
 
   async function handleDeleteLoot(item: LootItem) {
     await api.deleteLootItem(item.id)
-    setLootItems((items) => items.filter((entry) => entry.id !== item.id))
+    queryClient.setQueryData<LootItem[]>(['lootItems'], (items = []) =>
+      items.filter((entry) => entry.id !== item.id),
+    )
   }
 
   async function handleCreateBuild(build: Omit<Build, 'id'>) {
     const created = await api.createBuild(build)
-    setBuilds((items) => sortByName([...items, created]))
+    queryClient.setQueryData<Build[]>(['builds'], (items = []) => sortByName([...items, created]))
   }
 
   async function handleUpdateBuild(id: number, build: Omit<Build, 'id'>) {
     const updated = await api.updateBuild(id, build)
-    setBuilds((items) => sortByName(items.map((entry) => (entry.id === id ? updated : entry))))
+    queryClient.setQueryData<Build[]>(['builds'], (items = []) =>
+      sortByName(items.map((entry) => (entry.id === id ? updated : entry))),
+    )
   }
 
   async function handleDeleteBuild(id: number) {
     await api.deleteBuild(id)
-    setBuilds((items) => items.filter((entry) => entry.id !== id))
+    queryClient.setQueryData<Build[]>(['builds'], (items = []) => items.filter((entry) => entry.id !== id))
   }
 
   async function handleCreateEnemy(enemy: Omit<Enemy, 'id'>) {
     const created = await api.createEnemy(enemy)
-    setEnemies((items) => sortByName([...items, created]))
+    queryClient.setQueryData<Enemy[]>(['enemies'], (items = []) => sortByName([...items, created]))
   }
 
   async function handleUpdateEnemy(id: number, enemy: Omit<Enemy, 'id'>) {
     const updated = await api.updateEnemy(id, enemy)
-    setEnemies((items) => sortByName(items.map((entry) => (entry.id === id ? updated : entry))))
+    queryClient.setQueryData<Enemy[]>(['enemies'], (items = []) =>
+      sortByName(items.map((entry) => (entry.id === id ? updated : entry))),
+    )
   }
 
   async function handleDeleteEnemy(id: number) {
     await api.deleteEnemy(id)
-    setEnemies((items) => items.filter((entry) => entry.id !== id))
+    queryClient.setQueryData<Enemy[]>(['enemies'], (items = []) => items.filter((entry) => entry.id !== id))
   }
+
+  const lootItems = lootQuery.data ?? []
+  const builds = buildsQuery.data ?? []
+  const enemies = enemiesQuery.data ?? []
+  const armours = armoursQuery.data ?? []
+  const weapons = weaponsQuery.data ?? []
+  const spells = spellsQuery.data ?? []
+  const races = racesQuery.data ?? []
+  const classes = classesQuery.data ?? []
 
   const weaponNames = useMemo(() => weapons.map((weapon) => weapon.name), [weapons])
   const armourNames = useMemo(() => armours.map((armour) => armour.name), [armours])

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,15 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
 
+const queryClient = new QueryClient()
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add @tanstack/react-query and wrap the app with QueryClientProvider
- replace the previous effect-based data loading with individual useQuery hooks and query cache updates
- use React Query loading and error state in place of manual flags

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c87738fdcc832bbc959735eab31068