### PR TITLE
Add CI workflow for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt pytest
+
+      - name: Compile backend sources
+        run: python -m compileall backend
+
+      - name: Run backend tests
+        run: pytest
+        working-directory: backend
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Run frontend tests
+        working-directory: frontend
+        run: npm test

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "npm run lint",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add a CI workflow that sets up Python and Node, compiles the backend, runs pytest, and builds/tests the frontend
- define an npm `test` script so the workflow can execute frontend checks

## Testing
- python -m compileall backend
- pytest
- npm ci
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c878d8fcc0832bbb8a539d8ec46909