### PR TITLE
Add spells endpoint ordering and tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -489,8 +489,22 @@ def list_weapons() -> List[schemas.Weapon]:
 
 @app.get("/api/spells", response_model=List[schemas.Spell])
 def list_spells() -> List[schemas.Spell]:
-    spells = fetch_all("spells", "SELECT name, level, description FROM Spells")
-    properties = fetch_all("spells", "SELECT spell_name, property_name, property_value FROM Spell_Properties")
+    spells = fetch_all(
+        "spells",
+        """
+        SELECT name, level, description
+        FROM Spells
+        ORDER BY name COLLATE NOCASE
+        """,
+    )
+    properties = fetch_all(
+        "spells",
+        """
+        SELECT spell_name, property_name, property_value
+        FROM Spell_Properties
+        ORDER BY spell_name COLLATE NOCASE, property_name COLLATE NOCASE
+        """,
+    )
 
     prop_map: Dict[str, List[schemas.SpellProperty]] = defaultdict(list)
     for row in properties:

--- a/backend/tests/test_spells.py
+++ b/backend/tests/test_spells.py
@@ -1,0 +1,91 @@
+import sqlite3
+from typing import Any, Mapping
+
+import pytest
+
+from backend.app import database
+
+
+@pytest.fixture
+def spells_db(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    db_path = tmp_path / "test_spells.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE Spells (
+                name TEXT PRIMARY KEY,
+                level TEXT,
+                description TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE Spell_Properties (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                spell_name TEXT NOT NULL,
+                property_name TEXT NOT NULL,
+                property_value TEXT,
+                FOREIGN KEY (spell_name) REFERENCES Spells(name)
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO Spells (name, level, description)
+            VALUES (?, ?, ?)
+            """,
+            [
+                ("Magic Missile", "1", "Bolts of magical force strike targets."),
+                ("Fireball", "3", "A bright streak flashes to your chosen point."),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO Spell_Properties (spell_name, property_name, property_value)
+            VALUES (?, ?, ?)
+            """,
+            [
+                ("Magic Missile", "Casting Time", "1 action"),
+                ("Magic Missile", "Range", "120 feet"),
+                ("Fireball", "Area", "20-foot-radius sphere"),
+                ("Fireball", "Saving Throw", "DEX"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setitem(database.DATABASE_PATHS, "spells", db_path)
+    return db_path
+
+
+def _properties_by_name(spell: Mapping[str, Any]):
+    return {prop["name"]: prop["value"] for prop in spell["properties"]}
+
+
+def test_list_spells_returns_spells_with_properties(spells_db, client):
+    response = client.get("/api/spells")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert len(payload) == 2
+
+    spells = {spell["name"]: spell for spell in payload}
+
+    magic_missile = spells["Magic Missile"]
+    assert magic_missile["level"] == "1"
+    assert "Bolts of magical force" in magic_missile["description"]
+    assert _properties_by_name(magic_missile) == {
+        "Casting Time": "1 action",
+        "Range": "120 feet",
+    }
+
+    fireball = spells["Fireball"]
+    assert fireball["level"] == "3"
+    assert "bright streak" in (fireball.get("description") or "").lower()
+    assert _properties_by_name(fireball) == {
+        "Area": "20-foot-radius sphere",
+        "Saving Throw": "DEX",
+    }


### PR DESCRIPTION
## Summary
- sort the spells API query along with property results for stable ordering
- cover the spells endpoint with a sqlite-backed pytest fixture ensuring properties are returned

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68c880104f28832bb1530f4a91dcaa61