### PR TITLE
Add party planner import/export controls

### DIFF
--- a/frontend/src/components/PartyPlanner.tsx
+++ b/frontend/src/components/PartyPlanner.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
-import type { FormEvent } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { ChangeEvent, FormEvent } from 'react'
 import { useLocalStorage } from '../hooks'
 import type {
   AbilityScoreKey,
@@ -9,6 +9,7 @@ import type {
   Race,
   Spell,
 } from '../types'
+import { downloadJSON, readJSONFile } from '../utils/file'
 import { CharacterSheet } from './CharacterSheet'
 import { Panel } from './Panel'
 
@@ -50,6 +51,87 @@ const skillOptions = [
   'Survie',
 ]
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+function isAbilityScoreKey(value: string): value is AbilityScoreKey {
+  return abilityKeys.includes(value as AbilityScoreKey)
+}
+
+function isValidAbilityScores(value: unknown): value is Record<AbilityScoreKey, number> {
+  if (!isRecord(value)) return false
+  return abilityKeys.every((key) => {
+    const score = value[key]
+    return typeof score === 'number' && Number.isFinite(score)
+  })
+}
+
+function isValidPartyMember(value: unknown): value is PartyMember {
+  if (!isRecord(value)) return false
+
+  if (typeof value.id !== 'string') return false
+  if (typeof value.name !== 'string') return false
+  if (typeof value.level !== 'number' || !Number.isFinite(value.level) || !Number.isInteger(value.level)) return false
+  if (!isValidAbilityScores(value.abilityScores)) return false
+
+  if (!isStringArray(value.savingThrows)) return false
+  if (!value.savingThrows.every((item) => isAbilityScoreKey(item))) return false
+
+  if (!isStringArray(value.skills)) return false
+  if (!isStringArray(value.equippedWeapons)) return false
+  if (!isStringArray(value.spells)) return false
+
+  if (value.race !== undefined && typeof value.race !== 'string') return false
+  if (value.subrace !== undefined && typeof value.subrace !== 'string') return false
+  if (value.class_name !== undefined && typeof value.class_name !== 'string') return false
+  if (value.subclass !== undefined && typeof value.subclass !== 'string') return false
+  if (value.background !== undefined && typeof value.background !== 'string') return false
+  if (value.equippedArmour !== undefined && typeof value.equippedArmour !== 'string') return false
+  if (value.notes !== undefined && typeof value.notes !== 'string') return false
+
+  if (value.buildId !== undefined && typeof value.buildId !== 'number') return false
+
+  return true
+}
+
+function sanitizeMember(member: PartyMember): PartyMember {
+  return {
+    id: member.id,
+    name: member.name,
+    race: member.race ?? undefined,
+    subrace: member.subrace ?? undefined,
+    class_name: member.class_name ?? undefined,
+    subclass: member.subclass ?? undefined,
+    background: member.background ?? undefined,
+    level: member.level,
+    buildId: member.buildId ?? undefined,
+    abilityScores: abilityKeys.reduce<PartyMember['abilityScores']>((scores, key) => {
+      scores[key] = member.abilityScores[key]
+      return scores
+    }, {} as PartyMember['abilityScores']),
+    savingThrows: member.savingThrows.filter((savingThrow): savingThrow is AbilityScoreKey =>
+      abilityKeys.includes(savingThrow),
+    ),
+    skills: [...member.skills],
+    equippedWeapons: [...member.equippedWeapons],
+    equippedArmour: member.equippedArmour ?? undefined,
+    spells: [...member.spells],
+    notes: member.notes ?? undefined,
+  }
+}
+
+function parseImportedMembers(data: unknown): PartyMember[] | null {
+  if (!Array.isArray(data)) return null
+  if (!data.every((item) => isValidPartyMember(item))) return null
+
+  return data.map((member) => sanitizeMember(member))
+}
+
 function createEmptyMember(): PartyMember {
   return {
     id: crypto.randomUUID(),
@@ -77,6 +159,7 @@ export function PartyPlanner({ builds, races, classes, spells, weaponOptions, ar
   const [editingMember, setEditingMember] = useState<PartyMember | null>(null)
   const [spellQuery, setSpellQuery] = useState('')
   const [weaponInput, setWeaponInput] = useState('')
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const selectedMember = useMemo(
     () => members.find((member) => member.id === selectedId) ?? null,
@@ -182,6 +265,41 @@ export function PartyPlanner({ builds, races, classes, spells, weaponOptions, ar
     setEditingMember({ ...editingMember, spells: editingMember.spells.filter((spell) => spell !== name) })
   }
 
+  function handleExport() {
+    downloadJSON(members, 'bg3-party-members.json')
+  }
+
+  async function handleImport(event: ChangeEvent<HTMLInputElement>) {
+    const input = event.target
+    const file = input.files?.[0]
+    if (!file) return
+
+    try {
+      const data = await readJSONFile<unknown>(file)
+      const parsedMembers = parseImportedMembers(data)
+
+      if (!parsedMembers) {
+        window.alert('Le fichier ne correspond pas au format attendu.')
+        return
+      }
+
+      setMembers(parsedMembers)
+      setSelectedId(parsedMembers[0]?.id ?? null)
+      setEditingMember(null)
+      setSpellQuery('')
+      setWeaponInput('')
+    } catch (error) {
+      console.error('Failed to import party members', error)
+      window.alert("Impossible d'importer les membres. Vérifiez le fichier.")
+    } finally {
+      input.value = ''
+    }
+  }
+
+  function triggerImport() {
+    fileInputRef.current?.click()
+  }
+
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     if (!editingMember) return
@@ -202,9 +320,24 @@ export function PartyPlanner({ builds, races, classes, spells, weaponOptions, ar
         title="Gestion de l'équipe"
         subtitle="Personnalisez vos compagnons et assignez-leur des builds"
         actions={
-          <button className="link" onClick={startCreate}>
-            Ajouter un membre
-          </button>
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/json"
+              onChange={handleImport}
+              hidden
+            />
+            <button type="button" className="link" onClick={handleExport}>
+              Exporter
+            </button>
+            <button type="button" className="link" onClick={triggerImport}>
+              Importer
+            </button>
+            <button type="button" className="link" onClick={startCreate}>
+              Ajouter un membre
+            </button>
+          </>
         }
       >
         <div className="party-planner__layout">

--- a/frontend/src/utils/file.ts
+++ b/frontend/src/utils/file.ts
@@ -1,0 +1,37 @@
+export function downloadJSON(data: unknown, filename: string) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+
+  URL.revokeObjectURL(url)
+}
+
+export function readJSONFile<T>(file: File): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.onload = () => {
+      try {
+        if (typeof reader.result !== 'string') {
+          throw new Error('Invalid file content')
+        }
+        const result = JSON.parse(reader.result) as T
+        resolve(result)
+      } catch (error) {
+        reject(error)
+      }
+    }
+
+    reader.onerror = () => {
+      reject(reader.error ?? new Error('Failed to read file'))
+    }
+
+    reader.readAsText(file)
+  })
+}


### PR DESCRIPTION
## Summary
- add JSON helper utilities for downloading and reading files
- add import and export buttons to the party planner
- validate imported data before replacing stored party members

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8826e9b5c832b8f24c7703a99d19c