### PR TITLE
Refine character equipment planning

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -479,12 +479,6 @@ button:hover {
   text-transform: uppercase;
 }
 
-.weapon-input__row {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
 .tag-list {
   display: flex;
   flex-wrap: wrap;
@@ -520,6 +514,195 @@ button:hover {
   border-radius: 12px;
   background: rgba(248, 244, 232, 0.9);
   border: 1px solid rgba(59, 73, 92, 0.2);
+}
+
+.equipment-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.equipment-layout {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-rows: repeat(5, auto);
+  grid-template-areas:
+    '. head head amulet .'
+    'cloak . character . ring1'
+    'armour . character . ring2'
+    'handwear mainHand character offHand footwear'
+    '. clothing ranged ranged .';
+  gap: 0.75rem;
+  align-items: center;
+  justify-items: center;
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(59, 73, 92, 0.2);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.equipment-layout--sheet {
+  background: rgba(248, 244, 232, 0.85);
+}
+
+.equipment-layout__character {
+  grid-area: character;
+  width: 160px;
+  height: 220px;
+  border-radius: 16px;
+  border: 2px dashed rgba(59, 73, 92, 0.3);
+  background: radial-gradient(circle at 35% 20%, rgba(201, 178, 148, 0.35), rgba(248, 244, 232, 0.7));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0.85rem;
+  color: rgba(59, 73, 92, 0.85);
+  font-family: 'Cinzel', serif;
+  gap: 0.35rem;
+}
+
+.equipment-layout__character span:first-child {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.equipment-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+  max-width: 170px;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(59, 73, 92, 0.18);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+}
+
+.equipment-slot--read-only {
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.equipment-slot__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(59, 73, 92, 0.68);
+}
+
+.equipment-slot select {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid rgba(59, 73, 92, 0.28);
+  padding: 0.4rem 0.55rem;
+  background: rgba(248, 244, 232, 0.95);
+  color: rgba(44, 62, 80, 0.92);
+  font-size: 0.9rem;
+}
+
+.equipment-slot select:focus-visible {
+  outline: none;
+  border-color: rgba(140, 103, 70, 0.85);
+  box-shadow: 0 0 0 2px rgba(140, 103, 70, 0.35);
+}
+
+.equipment-slot__value {
+  font-weight: 600;
+  color: rgba(44, 62, 80, 0.9);
+}
+
+.equipment-slot__value--empty {
+  color: rgba(44, 62, 80, 0.55);
+  font-style: italic;
+}
+
+.equipment-slot--headwear {
+  grid-area: head;
+}
+
+.equipment-slot--amulet {
+  grid-area: amulet;
+}
+
+.equipment-slot--cloak {
+  grid-area: cloak;
+}
+
+.equipment-slot--armour {
+  grid-area: armour;
+}
+
+.equipment-slot--handwear {
+  grid-area: handwear;
+}
+
+.equipment-slot--footwear {
+  grid-area: footwear;
+}
+
+.equipment-slot--ring1 {
+  grid-area: ring1;
+}
+
+.equipment-slot--ring2 {
+  grid-area: ring2;
+}
+
+.equipment-slot--clothing {
+  grid-area: clothing;
+}
+
+.equipment-slot--mainHand {
+  grid-area: mainHand;
+}
+
+.equipment-slot--offHand {
+  grid-area: offHand;
+}
+
+.equipment-slot--ranged {
+  grid-area: ranged;
+}
+
+@media (max-width: 900px) {
+  .equipment-layout {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-areas:
+      'head head amulet'
+      'cloak character ring1'
+      'armour character ring2'
+      'handwear character offHand'
+      'footwear mainHand ranged'
+      'clothing clothing ranged';
+  }
+}
+
+@media (max-width: 640px) {
+  .equipment-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      'head character'
+      'amulet character'
+      'cloak mainHand'
+      'armour offHand'
+      'handwear ranged'
+      'footwear ranged'
+      'ring1 clothing'
+      'ring2 clothing';
+  }
+
+  .equipment-slot {
+    max-width: none;
+  }
+
+  .equipment-layout__character {
+    width: 140px;
+    height: 190px;
+  }
 }
 
 .spell-selector__header {
@@ -654,9 +837,9 @@ button:hover {
 }
 
 .character-sheet__equipment {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .character-sheet__spellbook {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -172,25 +172,33 @@ function App() {
     queryClient.setQueryData<Enemy[]>(['enemies'], (items = []) => items.filter((entry) => entry.id !== id))
   }
 
-  const lootItems = lootQuery.data ?? []
-  const builds = buildsQuery.data ?? []
-  const enemies = enemiesQuery.data ?? []
-  const armours = armoursQuery.data ?? []
-  const rings = ringsQuery.data ?? []
-  const amulets = amuletsQuery.data ?? []
-  const cloaks = cloaksQuery.data ?? []
-  const clothing = clothingQuery.data ?? []
-  const footwears = footwearsQuery.data ?? []
-  const handwears = handwearsQuery.data ?? []
-  const headwears = headwearsQuery.data ?? []
-  const shields = shieldsQuery.data ?? []
-  const weapons = weaponsQuery.data ?? []
-  const spells = spellsQuery.data ?? []
-  const races = racesQuery.data ?? []
-  const classes = classesQuery.data ?? []
+  const lootItems = useMemo(() => lootQuery.data ?? [], [lootQuery.data])
+  const builds = useMemo(() => buildsQuery.data ?? [], [buildsQuery.data])
+  const enemies = useMemo(() => enemiesQuery.data ?? [], [enemiesQuery.data])
+  const armours = useMemo(() => armoursQuery.data ?? [], [armoursQuery.data])
+  const rings = useMemo(() => ringsQuery.data ?? [], [ringsQuery.data])
+  const amulets = useMemo(() => amuletsQuery.data ?? [], [amuletsQuery.data])
+  const cloaks = useMemo(() => cloaksQuery.data ?? [], [cloaksQuery.data])
+  const clothing = useMemo(() => clothingQuery.data ?? [], [clothingQuery.data])
+  const footwears = useMemo(() => footwearsQuery.data ?? [], [footwearsQuery.data])
+  const handwears = useMemo(() => handwearsQuery.data ?? [], [handwearsQuery.data])
+  const headwears = useMemo(() => headwearsQuery.data ?? [], [headwearsQuery.data])
+  const shields = useMemo(() => shieldsQuery.data ?? [], [shieldsQuery.data])
+  const weapons = useMemo(() => weaponsQuery.data ?? [], [weaponsQuery.data])
+  const spells = useMemo(() => spellsQuery.data ?? [], [spellsQuery.data])
+  const races = useMemo(() => racesQuery.data ?? [], [racesQuery.data])
+  const classes = useMemo(() => classesQuery.data ?? [], [classesQuery.data])
 
   const weaponNames = useMemo(() => weapons.map((weapon) => weapon.name), [weapons])
   const armourNames = useMemo(() => armours.map((armour) => armour.name), [armours])
+  const shieldNames = useMemo(() => shields.map((shield) => shield.name), [shields])
+  const headwearNames = useMemo(() => headwears.map((item) => item.name), [headwears])
+  const handwearNames = useMemo(() => handwears.map((item) => item.name), [handwears])
+  const footwearNames = useMemo(() => footwears.map((item) => item.name), [footwears])
+  const cloakNames = useMemo(() => cloaks.map((item) => item.name), [cloaks])
+  const amuletNames = useMemo(() => amulets.map((item) => item.name), [amulets])
+  const ringNames = useMemo(() => rings.map((item) => item.name), [rings])
+  const clothingNames = useMemo(() => clothing.map((item) => item.name), [clothing])
 
   return (
     <div className="app">
@@ -227,6 +235,14 @@ function App() {
               spells={spells}
               weaponOptions={weaponNames}
               armourOptions={armourNames}
+              shieldOptions={shieldNames}
+              headwearOptions={headwearNames}
+              handwearOptions={handwearNames}
+              footwearOptions={footwearNames}
+              cloakOptions={cloakNames}
+              amuletOptions={amuletNames}
+              ringOptions={ringNames}
+              clothingOptions={clothingNames}
             />
           </div>
 

--- a/frontend/src/components/CharacterSheet.tsx
+++ b/frontend/src/components/CharacterSheet.tsx
@@ -1,4 +1,5 @@
 import type { AbilityScoreKey, Build, CharacterClass, PartyMember, Race, Spell } from '../types'
+import { equipmentSlotLabels, equipmentSlotOrder } from '../utils/equipment'
 import { Panel } from './Panel'
 
 interface CharacterSheetProps {
@@ -33,6 +34,7 @@ export function CharacterSheet({ member, build, raceInfo, classInfo, spells }: C
   }
 
   const knownSpells = spells.filter((spell) => member.spells.includes(spell.name))
+  const equipment = member.equipment ?? {}
   const nextLevel = Math.min(12, member.level + 1)
   const nextStep = build?.levels.find((level) => level.level === nextLevel)
 
@@ -144,19 +146,22 @@ export function CharacterSheet({ member, build, raceInfo, classInfo, spells }: C
       </section>
 
       <section className="character-sheet__equipment">
-        <div>
-          <h4>Armure</h4>
-          <p>{member.equippedArmour || 'Aucune armure assignée'}</p>
-        </div>
-        <div>
-          <h4>Armes</h4>
-          <ul className="tag-list">
-            {member.equippedWeapons.length ? (
-              member.equippedWeapons.map((weapon) => <li key={weapon}>{weapon}</li>)
-            ) : (
-              <li className="empty">—</li>
-            )}
-          </ul>
+        <h4>Équipement</h4>
+        <div className="equipment-layout equipment-layout--sheet">
+          <div className="equipment-layout__character" aria-hidden="true">
+            <span>{member.name}</span>
+          </div>
+          {equipmentSlotOrder.map((slot) => {
+            const value = equipment[slot]
+            return (
+              <div key={slot} className={`equipment-slot equipment-slot--${slot} equipment-slot--read-only`}>
+                <span className="equipment-slot__label">{equipmentSlotLabels[slot]}</span>
+                <span className={value ? 'equipment-slot__value' : 'equipment-slot__value equipment-slot__value--empty'}>
+                  {value ?? '—'}
+                </span>
+              </div>
+            )
+          })}
         </div>
       </section>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -248,6 +248,25 @@ export type AbilityScoreKey =
   | 'Wisdom'
   | 'Charisma'
 
+export const equipmentSlotKeys = [
+  'headwear',
+  'amulet',
+  'cloak',
+  'armour',
+  'handwear',
+  'footwear',
+  'ring1',
+  'ring2',
+  'clothing',
+  'mainHand',
+  'offHand',
+  'ranged',
+] as const
+
+export type EquipmentSlotKey = (typeof equipmentSlotKeys)[number]
+
+export type PartyEquipment = Partial<Record<EquipmentSlotKey, string>>
+
 export interface PartyMember {
   id: string
   name: string
@@ -261,8 +280,7 @@ export interface PartyMember {
   abilityScores: Record<AbilityScoreKey, number>
   savingThrows: AbilityScoreKey[]
   skills: string[]
-  equippedWeapons: string[]
-  equippedArmour?: string
+  equipment?: PartyEquipment
   spells: string[]
   notes?: string
 }

--- a/frontend/src/utils/equipment.ts
+++ b/frontend/src/utils/equipment.ts
@@ -1,0 +1,31 @@
+import type { EquipmentSlotKey } from '../types'
+
+export const equipmentSlotLabels: Record<EquipmentSlotKey, string> = {
+  headwear: 'Tête',
+  amulet: 'Amulette',
+  cloak: 'Cape',
+  armour: 'Armure',
+  handwear: 'Gants',
+  footwear: 'Bottes',
+  ring1: 'Bague (main gauche)',
+  ring2: 'Bague (main droite)',
+  clothing: 'Tenue de camp',
+  mainHand: 'Arme principale',
+  offHand: 'Main secondaire / Bouclier',
+  ranged: 'Arme à distance',
+}
+
+export const equipmentSlotOrder: EquipmentSlotKey[] = [
+  'headwear',
+  'amulet',
+  'cloak',
+  'armour',
+  'handwear',
+  'footwear',
+  'ring1',
+  'ring2',
+  'clothing',
+  'mainHand',
+  'offHand',
+  'ranged',
+]


### PR DESCRIPTION
## Summary
- allow selecting full equipment through slot-based dropdowns that mirror the in-game layout
- render the same slot layout on the character sheet to review equipped items at a glance
- persist equipment per slot and preload option lists from the database while removing the manual saving throw selector

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c88ab14d98832ba1fdc2d10145836f