### PR TITLE
Stack roster above editor in party planner

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -399,7 +399,7 @@ button:hover {
 .party-planner__layout {
   display: grid;
   gap: 1.25rem;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .party-planner__roster ul {


### PR DESCRIPTION
## Summary
- stack the party planner roster above the editor so the editor can use the full width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8967f2e10832ba343f29d63fb045c