### PR TITLE
Organize equipment panels into tabbed navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,21 +3,12 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import './App.css'
 import { api } from './api'
 import type { Build, Enemy, LootItem } from './types'
-import { AmuletPanel } from './components/AmuletPanel'
-import { ArmouryPanel } from './components/ArmouryPanel'
 import { BestiaryPanel } from './components/BestiaryPanel'
 import { BuildLibrary } from './components/BuildLibrary'
-import { CloakPanel } from './components/CloakPanel'
-import { ClothingPanel } from './components/ClothingPanel'
+import { EquipmentTabs } from './components/EquipmentTabs'
 import { LootChecklist } from './components/LootChecklist'
-import { FootwearPanel } from './components/FootwearPanel'
-import { HandwearPanel } from './components/HandwearPanel'
-import { HeadwearPanel } from './components/HeadwearPanel'
 import { PartyPlanner } from './components/PartyPlanner'
-import { RingPanel } from './components/RingPanel'
 import { SpellLibrary } from './components/SpellLibrary'
-import { ShieldPanel } from './components/ShieldPanel'
-import { WeaponPanel } from './components/WeaponPanel'
 
 function sortByName<T extends { name: string }>(items: T[]): T[] {
   return [...items].sort((a, b) => a.name.localeCompare(b.name, 'fr'))
@@ -253,16 +244,18 @@ function App() {
               onUpdate={handleUpdateBuild}
               onDelete={handleDeleteBuild}
             />
-            <ArmouryPanel armours={armours} />
-            <ShieldPanel shields={shields} />
-            <WeaponPanel weapons={weapons} />
-            <ClothingPanel clothing={clothing} />
-            <HeadwearPanel headwears={headwears} />
-            <HandwearPanel handwears={handwears} />
-            <FootwearPanel footwears={footwears} />
-            <CloakPanel cloaks={cloaks} />
-            <RingPanel rings={rings} />
-            <AmuletPanel amulets={amulets} />
+            <EquipmentTabs
+              armours={armours}
+              shields={shields}
+              weapons={weapons}
+              clothing={clothing}
+              headwears={headwears}
+              handwears={handwears}
+              footwears={footwears}
+              cloaks={cloaks}
+              rings={rings}
+              amulets={amulets}
+            />
             <BestiaryPanel
               enemies={enemies}
               onCreate={handleCreateEnemy}

--- a/frontend/src/components/AmuletPanel.tsx
+++ b/frontend/src/components/AmuletPanel.tsx
@@ -3,9 +3,10 @@ import { AccessoryPanel } from './AccessoryPanel'
 
 interface AmuletPanelProps {
   amulets: AmuletItem[]
+  defaultCollapsed?: boolean
 }
 
-export function AmuletPanel({ amulets }: AmuletPanelProps) {
+export function AmuletPanel({ amulets, defaultCollapsed = true }: AmuletPanelProps) {
   return (
     <AccessoryPanel
       items={amulets}
@@ -13,6 +14,7 @@ export function AmuletPanel({ amulets }: AmuletPanelProps) {
       subtitle="Choisissez les talismans qui protégeront votre groupe"
       searchPlaceholder="Rechercher une amulette"
       emptyLabel="Aucune amulette ne correspond à la recherche."
+      defaultCollapsed={defaultCollapsed}
     />
   )
 }

--- a/frontend/src/components/CloakPanel.tsx
+++ b/frontend/src/components/CloakPanel.tsx
@@ -3,9 +3,10 @@ import { AccessoryPanel } from './AccessoryPanel'
 
 interface CloakPanelProps {
   cloaks: CloakItem[]
+  defaultCollapsed?: boolean
 }
 
-export function CloakPanel({ cloaks }: CloakPanelProps) {
+export function CloakPanel({ cloaks, defaultCollapsed = true }: CloakPanelProps) {
   return (
     <AccessoryPanel
       items={cloaks}
@@ -13,6 +14,7 @@ export function CloakPanel({ cloaks }: CloakPanelProps) {
       subtitle="Trouvez la cape idéale pour vos subterfuges ou vos duels"
       searchPlaceholder="Rechercher une cape"
       emptyLabel="Aucune cape ne correspond à la recherche."
+      defaultCollapsed={defaultCollapsed}
     />
   )
 }

--- a/frontend/src/components/ClothingPanel.tsx
+++ b/frontend/src/components/ClothingPanel.tsx
@@ -3,9 +3,10 @@ import { AccessoryPanel } from './AccessoryPanel'
 
 interface ClothingPanelProps {
   clothing: ClothingItem[]
+  defaultCollapsed?: boolean
 }
 
-export function ClothingPanel({ clothing }: ClothingPanelProps) {
+export function ClothingPanel({ clothing, defaultCollapsed = true }: ClothingPanelProps) {
   return (
     <AccessoryPanel
       items={clothing}
@@ -21,6 +22,7 @@ export function ClothingPanel({ clothing }: ClothingPanelProps) {
           </p>
         ) : null
       }
+      defaultCollapsed={defaultCollapsed}
     />
   )
 }

--- a/frontend/src/components/EquipmentTabs.tsx
+++ b/frontend/src/components/EquipmentTabs.tsx
@@ -1,0 +1,228 @@
+import { useId, useRef, useState } from 'react'
+import type { KeyboardEvent } from 'react'
+import type {
+  AmuletItem,
+  ArmourItem,
+  CloakItem,
+  ClothingItem,
+  FootwearItem,
+  HandwearItem,
+  HeadwearItem,
+  RingItem,
+  ShieldItem,
+  WeaponItem,
+} from '../types'
+import { AmuletPanel } from './AmuletPanel'
+import { ArmouryPanel } from './ArmouryPanel'
+import { CloakPanel } from './CloakPanel'
+import { ClothingPanel } from './ClothingPanel'
+import { FootwearPanel } from './FootwearPanel'
+import { HandwearPanel } from './HandwearPanel'
+import { HeadwearPanel } from './HeadwearPanel'
+import { RingPanel } from './RingPanel'
+import { ShieldPanel } from './ShieldPanel'
+import { WeaponPanel } from './WeaponPanel'
+import './equipment-tabs.css'
+
+type EquipmentTabId =
+  | 'armours'
+  | 'shields'
+  | 'weapons'
+  | 'clothing'
+  | 'headwears'
+  | 'handwears'
+  | 'footwears'
+  | 'cloaks'
+  | 'rings'
+  | 'amulets'
+
+interface EquipmentTabsProps {
+  armours: ArmourItem[]
+  shields: ShieldItem[]
+  weapons: WeaponItem[]
+  clothing: ClothingItem[]
+  headwears: HeadwearItem[]
+  handwears: HandwearItem[]
+  footwears: FootwearItem[]
+  cloaks: CloakItem[]
+  rings: RingItem[]
+  amulets: AmuletItem[]
+}
+
+type TabRefMap = Record<EquipmentTabId, HTMLButtonElement | null>
+
+export function EquipmentTabs({
+  armours,
+  shields,
+  weapons,
+  clothing,
+  headwears,
+  handwears,
+  footwears,
+  cloaks,
+  rings,
+  amulets,
+}: EquipmentTabsProps) {
+  const [activeTab, setActiveTab] = useState<EquipmentTabId>('armours')
+  const idPrefix = useId()
+  const tabRefs = useRef<TabRefMap>({
+    armours: null,
+    shields: null,
+    weapons: null,
+    clothing: null,
+    headwears: null,
+    handwears: null,
+    footwears: null,
+    cloaks: null,
+    rings: null,
+    amulets: null,
+  })
+
+  const tabs = [
+    {
+      id: 'armours' as const,
+      label: 'Armurerie',
+      content: <ArmouryPanel armours={armours} />,
+    },
+    {
+      id: 'shields' as const,
+      label: 'Boucliers',
+      content: <ShieldPanel shields={shields} defaultCollapsed={false} />,
+    },
+    {
+      id: 'weapons' as const,
+      label: 'Arsenal',
+      content: <WeaponPanel weapons={weapons} />,
+    },
+    {
+      id: 'clothing' as const,
+      label: 'Tenues',
+      content: <ClothingPanel clothing={clothing} defaultCollapsed={false} />,
+    },
+    {
+      id: 'headwears' as const,
+      label: 'Coiffes',
+      content: <HeadwearPanel headwears={headwears} defaultCollapsed={false} />,
+    },
+    {
+      id: 'handwears' as const,
+      label: 'Gants',
+      content: <HandwearPanel handwears={handwears} defaultCollapsed={false} />,
+    },
+    {
+      id: 'footwears' as const,
+      label: 'Bottes & chaussures',
+      content: <FootwearPanel footwears={footwears} defaultCollapsed={false} />,
+    },
+    {
+      id: 'cloaks' as const,
+      label: 'Capes',
+      content: <CloakPanel cloaks={cloaks} defaultCollapsed={false} />,
+    },
+    {
+      id: 'rings' as const,
+      label: 'Anneaux',
+      content: <RingPanel rings={rings} defaultCollapsed={false} />,
+    },
+    {
+      id: 'amulets' as const,
+      label: 'Amulettes',
+      content: <AmuletPanel amulets={amulets} defaultCollapsed={false} />,
+    },
+  ]
+
+  function focusTab(tabId: EquipmentTabId) {
+    const button = tabRefs.current[tabId]
+    if (button) {
+      button.focus()
+    }
+  }
+
+  function selectTab(tabId: EquipmentTabId) {
+    setActiveTab(tabId)
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    switch (event.key) {
+      case 'ArrowRight': {
+        event.preventDefault()
+        const nextIndex = (index + 1) % tabs.length
+        const nextTab = tabs[nextIndex]
+        selectTab(nextTab.id)
+        focusTab(nextTab.id)
+        break
+      }
+      case 'ArrowLeft': {
+        event.preventDefault()
+        const nextIndex = (index - 1 + tabs.length) % tabs.length
+        const nextTab = tabs[nextIndex]
+        selectTab(nextTab.id)
+        focusTab(nextTab.id)
+        break
+      }
+      case 'Home': {
+        event.preventDefault()
+        const firstTab = tabs[0]
+        selectTab(firstTab.id)
+        focusTab(firstTab.id)
+        break
+      }
+      case 'End': {
+        event.preventDefault()
+        const lastTab = tabs[tabs.length - 1]
+        selectTab(lastTab.id)
+        focusTab(lastTab.id)
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  return (
+    <div className="equipment-tabs">
+      <div role="tablist" aria-label="Catégories d'équipement" className="equipment-tabs__list">
+        {tabs.map((tab, index) => {
+          const buttonClassName = [
+            'equipment-tabs__tab',
+            activeTab === tab.id ? 'equipment-tabs__tab--active' : undefined,
+          ]
+            .filter(Boolean)
+            .join(' ')
+
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              id={`${idPrefix}-${tab.id}-tab`}
+              aria-controls={`${idPrefix}-${tab.id}-panel`}
+              aria-selected={activeTab === tab.id}
+              tabIndex={activeTab === tab.id ? 0 : -1}
+              className={buttonClassName}
+              onClick={() => selectTab(tab.id)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              ref={(element) => {
+                tabRefs.current[tab.id] = element
+              }}
+            >
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+      {tabs.map((tab) => (
+        <div
+          key={tab.id}
+          role="tabpanel"
+          id={`${idPrefix}-${tab.id}-panel`}
+          aria-labelledby={`${idPrefix}-${tab.id}-tab`}
+          className="equipment-tabs__panel"
+          hidden={activeTab !== tab.id}
+        >
+          {tab.content}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/FootwearPanel.tsx
+++ b/frontend/src/components/FootwearPanel.tsx
@@ -3,9 +3,10 @@ import { AccessoryPanel } from './AccessoryPanel'
 
 interface FootwearPanelProps {
   footwears: FootwearItem[]
+  defaultCollapsed?: boolean
 }
 
-export function FootwearPanel({ footwears }: FootwearPanelProps) {
+export function FootwearPanel({ footwears, defaultCollapsed = true }: FootwearPanelProps) {
   return (
     <AccessoryPanel
       items={footwears}
@@ -18,6 +19,7 @@ export function FootwearPanel({ footwears }: FootwearPanelProps) {
           <p className="accessory-grid__details">Maîtrise requise : {item.required_proficiency}</p>
         ) : null
       }
+      defaultCollapsed={defaultCollapsed}
     />
   )
 }

--- a/frontend/src/components/HandwearPanel.tsx
+++ b/frontend/src/components/HandwearPanel.tsx
@@ -3,9 +3,10 @@ import { AccessoryPanel } from './AccessoryPanel'
 
 interface HandwearPanelProps {
   handwears: HandwearItem[]
+  defaultCollapsed?: boolean
 }
 
-export function HandwearPanel({ handwears }: HandwearPanelProps) {
+export function HandwearPanel({ handwears, defaultCollapsed = true }: HandwearPanelProps) {
   return (
     <AccessoryPanel
       items={handwears}
@@ -13,6 +14,7 @@ export function HandwearPanel({ handwears }: HandwearPanelProps) {
       subtitle="Comparez les gants pour optimiser vos actions et compétences"
       searchPlaceholder="Rechercher des gants"
       emptyLabel="Aucun gant ne correspond à la recherche."
+      defaultCollapsed={defaultCollapsed}
     />
   )
 }

--- a/frontend/src/components/HeadwearPanel.tsx
+++ b/frontend/src/components/HeadwearPanel.tsx
@@ -3,9 +3,10 @@ import { AccessoryPanel } from './AccessoryPanel'
 
 interface HeadwearPanelProps {
   headwears: HeadwearItem[]
+  defaultCollapsed?: boolean
 }
 
-export function HeadwearPanel({ headwears }: HeadwearPanelProps) {
+export function HeadwearPanel({ headwears, defaultCollapsed = true }: HeadwearPanelProps) {
   return (
     <AccessoryPanel
       items={headwears}
@@ -13,6 +14,7 @@ export function HeadwearPanel({ headwears }: HeadwearPanelProps) {
       subtitle="Choisissez les couvre-chefs adaptés à chaque situation"
       searchPlaceholder="Rechercher une coiffe"
       emptyLabel="Aucune coiffe ne correspond à la recherche."
+      defaultCollapsed={defaultCollapsed}
     />
   )
 }

--- a/frontend/src/components/RingPanel.tsx
+++ b/frontend/src/components/RingPanel.tsx
@@ -3,9 +3,10 @@ import { AccessoryPanel } from './AccessoryPanel'
 
 interface RingPanelProps {
   rings: RingItem[]
+  defaultCollapsed?: boolean
 }
 
-export function RingPanel({ rings }: RingPanelProps) {
+export function RingPanel({ rings, defaultCollapsed = true }: RingPanelProps) {
   return (
     <AccessoryPanel
       items={rings}
@@ -13,6 +14,7 @@ export function RingPanel({ rings }: RingPanelProps) {
       subtitle="Repérez les anneaux et leurs enchantements uniques"
       searchPlaceholder="Rechercher un anneau"
       emptyLabel="Aucun anneau ne correspond à la recherche."
+      defaultCollapsed={defaultCollapsed}
     />
   )
 }

--- a/frontend/src/components/ShieldPanel.tsx
+++ b/frontend/src/components/ShieldPanel.tsx
@@ -3,9 +3,10 @@ import { AccessoryPanel } from './AccessoryPanel'
 
 interface ShieldPanelProps {
   shields: ShieldItem[]
+  defaultCollapsed?: boolean
 }
 
-export function ShieldPanel({ shields }: ShieldPanelProps) {
+export function ShieldPanel({ shields, defaultCollapsed = true }: ShieldPanelProps) {
   return (
     <AccessoryPanel
       items={shields}
@@ -18,6 +19,7 @@ export function ShieldPanel({ shields }: ShieldPanelProps) {
           <p className="accessory-grid__details">Classe de bouclier : {item.shield_class_base}</p>
         ) : null
       }
+      defaultCollapsed={defaultCollapsed}
     />
   )
 }

--- a/frontend/src/components/equipment-tabs.css
+++ b/frontend/src/components/equipment-tabs.css
@@ -1,0 +1,64 @@
+.equipment-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.equipment-tabs__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0.25rem 0;
+  margin: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.equipment-tabs__list::-webkit-scrollbar {
+  height: 6px;
+}
+
+.equipment-tabs__list::-webkit-scrollbar-thumb {
+  background: rgba(48, 62, 80, 0.3);
+  border-radius: 999px;
+}
+
+.equipment-tabs__tab {
+  border: 1px solid rgba(48, 62, 80, 0.35);
+  background: rgba(255, 255, 255, 0.6);
+  color: rgba(44, 62, 80, 0.9);
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.equipment-tabs__tab:hover,
+.equipment-tabs__tab:focus-visible {
+  background: rgba(48, 62, 80, 0.18);
+}
+
+.equipment-tabs__tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(44, 62, 80, 0.35);
+}
+
+.equipment-tabs__tab--active {
+  background: rgba(48, 62, 80, 0.25);
+  color: #2c3e50;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6), 0 4px 10px rgba(44, 62, 80, 0.18);
+}
+
+.equipment-tabs__panel {
+  width: 100%;
+}
+
+.equipment-tabs__panel[hidden] {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- replace the stack of equipment panels with a new `EquipmentTabs` component that keeps only one category visible at a time
- add tab styles and keyboard interactions so switching between armour, shields, weapons and accessories is compact and accessible
- allow accessory-based panels to opt out of their default collapsed state so the active tab opens directly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c917383628832b8f092d8cdf81c2a5