### PR TITLE
feat: display equipment with icon tooltips

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/node": "^24.5.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1429,6 +1430,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.0.tgz",
+      "integrity": "sha512-y1dMvuvJspJiPSDZUQ+WMBvF7dpnEqN4x9DDC9ie5Fs/HUZJA3wFp7EhHoVaKX/iI0cRoECV8X2jL8zi0xrHCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.13",
@@ -3219,6 +3230,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/node": "^24.5.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -913,49 +913,180 @@ button:hover {
   align-items: center;
 }
 
-.armour-grid,
-.weapon-grid,
-.accessory-grid,
-.spell-library {
+.icon-grid {
   display: grid;
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 0.85rem;
+  position: relative;
+  overflow: visible;
 }
 
-.armour-grid article,
-.weapon-grid article,
-.accessory-grid article,
-.spell-library article {
+.icon-grid__item {
+  position: relative;
+  border-radius: 14px;
+  padding: 0.85rem 0.65rem 1.05rem;
+  border: 1px solid rgba(59, 73, 92, 0.18);
+  background: rgba(255, 255, 255, 0.92);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.55rem;
+  text-align: center;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  outline: none;
+}
+
+.icon-grid__item:hover,
+.icon-grid__item:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(140, 103, 70, 0.5);
+  box-shadow: 0 10px 18px rgba(140, 103, 70, 0.18);
+}
+
+.icon-grid__item:focus-visible {
+  box-shadow:
+    0 0 0 2px rgba(140, 103, 70, 0.45),
+    0 10px 18px rgba(140, 103, 70, 0.18);
+}
+
+.icon-grid__image {
+  width: 70px;
+  height: 70px;
   border-radius: 12px;
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(59, 73, 92, 0.2);
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(59, 73, 92, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.icon-grid__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.icon-grid__placeholder {
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  color: rgba(59, 73, 92, 0.6);
+}
+
+.icon-grid__label {
+  font-size: 0.85rem;
+  line-height: 1.3;
+  font-weight: 700;
+  color: #2c3e50;
+}
+
+.icon-grid__tooltip {
+  position: absolute;
+  top: calc(100% + 0.55rem);
+  left: 50%;
+  transform: translate(-50%, 6px);
+  min-width: 220px;
+  max-width: 320px;
+  max-height: 360px;
+  background: rgba(22, 24, 27, 0.95);
+  color: #f7f1e3;
+  border-radius: 10px;
+  padding: 0.9rem;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  z-index: 30;
+  overflow-y: auto;
+}
+
+.icon-grid__tooltip::before {
+  content: '';
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-bottom-color: rgba(22, 24, 27, 0.95);
+}
+
+.icon-grid__item:hover .icon-grid__tooltip,
+.icon-grid__item:focus-visible .icon-grid__tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.icon-grid__tooltip-content {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.icon-grid__tooltip-meta {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.icon-grid__tooltip-meta span {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: baseline;
+}
+
+.icon-grid__tooltip-meta strong {
+  color: #f4c887;
+}
+
+.icon-grid__tooltip-description {
+  margin: 0;
+}
+
+.icon-grid__tooltip-section {
   display: grid;
   gap: 0.35rem;
 }
 
-.armour-grid__specials,
-.weapon-grid__damage,
-.weapon-grid__actions,
-.accessory-grid__specials {
+.icon-grid__tooltip-section > strong {
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #f4c887;
+}
+
+.icon-grid__tooltip-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
-.accessory-grid__rarity {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 700;
-  color: rgba(59, 73, 92, 0.7);
+.icon-grid__tooltip-list li {
+  display: grid;
+  gap: 0.2rem;
 }
 
-.accessory-grid__location,
-.accessory-grid__details {
-  font-size: 0.85rem;
-  color: rgba(59, 73, 92, 0.8);
+.icon-grid__tooltip-list-title {
+  font-weight: 600;
+  color: #fbdba2;
+}
+
+.icon-grid__tooltip-quote {
+  margin: 0;
+  font-style: italic;
+  opacity: 0.85;
+}
+
+@media (max-width: 720px) {
+  .icon-grid {
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  }
+
+  .icon-grid__image {
+    width: 60px;
+    height: 60px;
+  }
 }
 
 .bestiary {

--- a/frontend/src/components/AccessoryPanel.tsx
+++ b/frontend/src/components/AccessoryPanel.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState, type ReactNode } from 'react'
 import type { AccessoryItemBase } from '../types'
 import { Panel } from './Panel'
+import { IconCard } from './IconCard'
+import { getIconUrl, type IconCategory } from '../utils/icons'
 
 interface AccessoryPanelProps<T extends AccessoryItemBase> {
   items: T[]
@@ -9,6 +11,7 @@ interface AccessoryPanelProps<T extends AccessoryItemBase> {
   searchPlaceholder: string
   emptyLabel: string
   typeLabel?: string
+  iconCategory: IconCategory
   renderDetails?: (item: T) => ReactNode
   defaultCollapsed?: boolean
 }
@@ -20,6 +23,7 @@ export function AccessoryPanel<T extends AccessoryItemBase>({
   searchPlaceholder,
   emptyLabel,
   typeLabel = 'Type',
+  iconCategory,
   renderDetails,
   defaultCollapsed = true,
 }: AccessoryPanelProps<T>) {
@@ -85,29 +89,60 @@ export function AccessoryPanel<T extends AccessoryItemBase>({
           ))}
         </select>
       </div>
-      <div className="accessory-grid">
-        {filtered.map((item) => (
-          <article key={item.item_id}>
-            <header>
-              <h4>{item.name}</h4>
-              <p>{item.type}</p>
-            </header>
-            <p className="accessory-grid__rarity">{item.rarity}</p>
-            {renderDetails ? renderDetails(item) : null}
-            {item.locations.length ? (
-              <p className="accessory-grid__location">{item.locations[0].description}</p>
-            ) : null}
-            {item.specials.length ? (
-              <ul className="accessory-grid__specials">
-                {item.specials.slice(0, 2).map((special) => (
-                  <li key={special.name}>
-                    <strong>{special.name} :</strong> {special.effect}
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-          </article>
-        ))}
+      <div className="icon-grid accessory-grid">
+        {filtered.map((item) => {
+          const location = item.locations[0]?.description
+          const specials = item.specials.slice(0, 3)
+          const extraDetail = renderDetails ? renderDetails(item) : null
+
+          return (
+            <IconCard key={item.item_id} name={item.name} iconUrl={getIconUrl(iconCategory, item.name)}>
+              <div className="icon-grid__tooltip-meta">
+                {item.type ? (
+                  <span>
+                    <strong>Type :</strong> {item.type}
+                  </span>
+                ) : null}
+                {item.rarity ? (
+                  <span>
+                    <strong>Rareté :</strong> {item.rarity}
+                  </span>
+                ) : null}
+                {extraDetail ? <span>{extraDetail}</span> : null}
+                {item.price_gp != null ? (
+                  <span>
+                    <strong>Prix :</strong> {item.price_gp} po
+                  </span>
+                ) : null}
+              </div>
+              {item.description ? (
+                <p className="icon-grid__tooltip-description">{item.description}</p>
+              ) : null}
+              {specials.length ? (
+                <div className="icon-grid__tooltip-section">
+                  <strong>Effets</strong>
+                  <ul className="icon-grid__tooltip-list">
+                    {specials.map((special) => (
+                      <li key={special.name}>
+                        <span className="icon-grid__tooltip-list-title">{special.name}</span>
+                        {special.effect ? <span>{special.effect}</span> : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {location ? (
+                <div className="icon-grid__tooltip-section">
+                  <strong>Obtention</strong>
+                  <p>{location}</p>
+                </div>
+              ) : null}
+              {item.quote ? (
+                <p className="icon-grid__tooltip-quote">{item.quote}</p>
+              ) : null}
+            </IconCard>
+          )
+        })}
         {!filtered.length ? <p className="empty">{emptyLabel}</p> : null}
       </div>
     </Panel>

--- a/frontend/src/components/AmuletPanel.tsx
+++ b/frontend/src/components/AmuletPanel.tsx
@@ -14,6 +14,7 @@ export function AmuletPanel({ amulets, defaultCollapsed = true }: AmuletPanelPro
       subtitle="Choisissez les talismans qui protégeront votre groupe"
       searchPlaceholder="Rechercher une amulette"
       emptyLabel="Aucune amulette ne correspond à la recherche."
+      iconCategory="amulet"
       defaultCollapsed={defaultCollapsed}
     />
   )

--- a/frontend/src/components/ArmouryPanel.tsx
+++ b/frontend/src/components/ArmouryPanel.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import type { ArmourItem } from '../types'
 import { Panel } from './Panel'
+import { IconCard } from './IconCard'
+import { getIconUrl } from '../utils/icons'
 
 interface ArmouryPanelProps {
   armours: ArmourItem[]
@@ -52,32 +54,59 @@ export function ArmouryPanel({ armours }: ArmouryPanelProps) {
           ))}
         </select>
       </div>
-      <div className="armour-grid">
-        {filtered.map((item) => (
-          <article key={item.item_id}>
-            <header>
-              <h4>{item.name}</h4>
-              <p>{item.type}</p>
-            </header>
-            <p className="armour-grid__rarity">{item.rarity}</p>
-            <p className="armour-grid__stats">
-              CA de base : {item.armour_class_base ?? '—'}{' '}
-              {item.armour_class_modifier ? `(${item.armour_class_modifier})` : ''}
-            </p>
-            {item.locations.length ? (
-              <p className="armour-grid__location">{item.locations[0].description}</p>
-            ) : null}
-            {item.specials.length ? (
-              <ul className="armour-grid__specials">
-                {item.specials.slice(0, 2).map((special) => (
-                  <li key={special.name}>
-                    <strong>{special.name} :</strong> {special.effect}
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-          </article>
-        ))}
+      <div className="icon-grid armour-grid">
+        {filtered.map((item) => {
+          const specials = item.specials.slice(0, 3)
+          const location = item.locations[0]?.description
+
+          return (
+            <IconCard key={item.item_id} name={item.name} iconUrl={getIconUrl('armour', item.name)}>
+              <div className="icon-grid__tooltip-meta">
+                {item.type ? (
+                  <span>
+                    <strong>Type :</strong> {item.type}
+                  </span>
+                ) : null}
+                {item.rarity ? (
+                  <span>
+                    <strong>Rareté :</strong> {item.rarity}
+                  </span>
+                ) : null}
+                <span>
+                  <strong>Classe d'armure :</strong> {item.armour_class_base ?? '—'}
+                  {item.armour_class_modifier ? ` (${item.armour_class_modifier})` : ''}
+                </span>
+                {item.weight_kg != null ? (
+                  <span>
+                    <strong>Poids :</strong> {item.weight_kg} kg
+                  </span>
+                ) : null}
+              </div>
+              {item.description ? (
+                <p className="icon-grid__tooltip-description">{item.description}</p>
+              ) : null}
+              {specials.length ? (
+                <div className="icon-grid__tooltip-section">
+                  <strong>Effets</strong>
+                  <ul className="icon-grid__tooltip-list">
+                    {specials.map((special) => (
+                      <li key={special.name}>
+                        <span className="icon-grid__tooltip-list-title">{special.name}</span>
+                        {special.effect ? <span>{special.effect}</span> : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {location ? (
+                <div className="icon-grid__tooltip-section">
+                  <strong>Obtention</strong>
+                  <p>{location}</p>
+                </div>
+              ) : null}
+            </IconCard>
+          )
+        })}
         {!filtered.length ? <p className="empty">Aucune armure ne correspond à la recherche.</p> : null}
       </div>
     </Panel>

--- a/frontend/src/components/CloakPanel.tsx
+++ b/frontend/src/components/CloakPanel.tsx
@@ -14,6 +14,7 @@ export function CloakPanel({ cloaks, defaultCollapsed = true }: CloakPanelProps)
       subtitle="Trouvez la cape idéale pour vos subterfuges ou vos duels"
       searchPlaceholder="Rechercher une cape"
       emptyLabel="Aucune cape ne correspond à la recherche."
+      iconCategory="cloak"
       defaultCollapsed={defaultCollapsed}
     />
   )

--- a/frontend/src/components/ClothingPanel.tsx
+++ b/frontend/src/components/ClothingPanel.tsx
@@ -14,12 +14,13 @@ export function ClothingPanel({ clothing, defaultCollapsed = true }: ClothingPan
       subtitle="Assurez-vous que chaque aventurier dispose de la tenue adéquate"
       searchPlaceholder="Rechercher une tenue"
       emptyLabel="Aucune tenue ne correspond à la recherche."
+      iconCategory="clothing"
       renderDetails={(item) =>
         item.armour_class_base != null || item.armour_class_modifier ? (
-          <p className="accessory-grid__details">
-            CA de base : {item.armour_class_base ?? '—'}{' '}
+          <>
+            <strong>Classe d'armure :</strong> {item.armour_class_base ?? '—'}{' '}
             {item.armour_class_modifier ? `(${item.armour_class_modifier})` : ''}
-          </p>
+          </>
         ) : null
       }
       defaultCollapsed={defaultCollapsed}

--- a/frontend/src/components/FootwearPanel.tsx
+++ b/frontend/src/components/FootwearPanel.tsx
@@ -14,9 +14,12 @@ export function FootwearPanel({ footwears, defaultCollapsed = true }: FootwearPa
       subtitle="Sélectionnez la bonne foulée pour vos héros"
       searchPlaceholder="Rechercher une paire"
       emptyLabel="Aucune paire ne correspond à la recherche."
+      iconCategory="footwear"
       renderDetails={(item) =>
         item.required_proficiency ? (
-          <p className="accessory-grid__details">Maîtrise requise : {item.required_proficiency}</p>
+          <>
+            <strong>Maîtrise requise :</strong> {item.required_proficiency}
+          </>
         ) : null
       }
       defaultCollapsed={defaultCollapsed}

--- a/frontend/src/components/HandwearPanel.tsx
+++ b/frontend/src/components/HandwearPanel.tsx
@@ -14,6 +14,7 @@ export function HandwearPanel({ handwears, defaultCollapsed = true }: HandwearPa
       subtitle="Comparez les gants pour optimiser vos actions et compétences"
       searchPlaceholder="Rechercher des gants"
       emptyLabel="Aucun gant ne correspond à la recherche."
+      iconCategory="handwear"
       defaultCollapsed={defaultCollapsed}
     />
   )

--- a/frontend/src/components/HeadwearPanel.tsx
+++ b/frontend/src/components/HeadwearPanel.tsx
@@ -14,6 +14,7 @@ export function HeadwearPanel({ headwears, defaultCollapsed = true }: HeadwearPa
       subtitle="Choisissez les couvre-chefs adaptés à chaque situation"
       searchPlaceholder="Rechercher une coiffe"
       emptyLabel="Aucune coiffe ne correspond à la recherche."
+      iconCategory="headwear"
       defaultCollapsed={defaultCollapsed}
     />
   )

--- a/frontend/src/components/IconCard.tsx
+++ b/frontend/src/components/IconCard.tsx
@@ -1,0 +1,41 @@
+import { useId, type ReactNode } from 'react'
+
+interface IconCardProps {
+  name: string
+  iconUrl: string | null
+  children?: ReactNode
+}
+
+export function IconCard({ name, iconUrl, children }: IconCardProps) {
+  const tooltipId = useId()
+  const hasTooltip = Boolean(children)
+
+  return (
+    <div
+      className="icon-grid__item"
+      tabIndex={0}
+      aria-describedby={hasTooltip ? tooltipId : undefined}
+    >
+      <div className="icon-grid__image" aria-hidden="true">
+        {iconUrl ? (
+          <img src={iconUrl} alt="" loading="lazy" />
+        ) : (
+          <span className="icon-grid__placeholder" aria-hidden="true">
+            {name
+              .split(' ')
+              .map((part) => part.charAt(0))
+              .join('')
+              .slice(0, 2)
+              .toUpperCase() || '?'}
+          </span>
+        )}
+      </div>
+      <span className="icon-grid__label">{name}</span>
+      {hasTooltip ? (
+        <div className="icon-grid__tooltip" id={tooltipId} role="tooltip">
+          <div className="icon-grid__tooltip-content">{children}</div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/RingPanel.tsx
+++ b/frontend/src/components/RingPanel.tsx
@@ -14,6 +14,7 @@ export function RingPanel({ rings, defaultCollapsed = true }: RingPanelProps) {
       subtitle="Repérez les anneaux et leurs enchantements uniques"
       searchPlaceholder="Rechercher un anneau"
       emptyLabel="Aucun anneau ne correspond à la recherche."
+      iconCategory="ring"
       defaultCollapsed={defaultCollapsed}
     />
   )

--- a/frontend/src/components/ShieldPanel.tsx
+++ b/frontend/src/components/ShieldPanel.tsx
@@ -14,9 +14,12 @@ export function ShieldPanel({ shields, defaultCollapsed = true }: ShieldPanelPro
       subtitle="Identifiez les boucliers qui compléteront vos défenses"
       searchPlaceholder="Rechercher un bouclier"
       emptyLabel="Aucun bouclier ne correspond à la recherche."
+      iconCategory="shield"
       renderDetails={(item) =>
         item.shield_class_base != null ? (
-          <p className="accessory-grid__details">Classe de bouclier : {item.shield_class_base}</p>
+          <>
+            <strong>Classe de bouclier :</strong> {item.shield_class_base}
+          </>
         ) : null
       }
       defaultCollapsed={defaultCollapsed}

--- a/frontend/src/components/SpellLibrary.tsx
+++ b/frontend/src/components/SpellLibrary.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import type { Spell } from '../types'
 import { Panel } from './Panel'
+import { IconCard } from './IconCard'
+import { getIconUrl } from '../utils/icons'
 
 interface SpellLibraryProps {
   spells: Spell[]
@@ -38,24 +40,33 @@ export function SpellLibrary({ spells }: SpellLibraryProps) {
           ))}
         </select>
       </div>
-      <div className="spell-library">
+      <div className="icon-grid spell-library">
         {filtered.map((spell) => (
-          <article key={spell.name}>
-            <header>
-              <h4>{spell.name}</h4>
-              {spell.level ? <span>Niv. {spell.level}</span> : null}
-            </header>
-            <p>{spell.description}</p>
-            {spell.properties.length ? (
-              <ul>
-                {spell.properties.slice(0, 3).map((property) => (
-                  <li key={property.name}>
-                    <strong>{property.name} :</strong> {property.value}
-                  </li>
-                ))}
-              </ul>
+          <IconCard key={spell.name} name={spell.name} iconUrl={getIconUrl('spell', spell.name)}>
+            <div className="icon-grid__tooltip-meta">
+              {spell.level ? (
+                <span>
+                  <strong>Niveau :</strong> {spell.level}
+                </span>
+              ) : null}
+            </div>
+            {spell.description ? (
+              <p className="icon-grid__tooltip-description">{spell.description}</p>
             ) : null}
-          </article>
+            {spell.properties.length ? (
+              <div className="icon-grid__tooltip-section">
+                <strong>Propriétés</strong>
+                <ul className="icon-grid__tooltip-list">
+                  {spell.properties.slice(0, 4).map((property) => (
+                    <li key={property.name}>
+                      <span className="icon-grid__tooltip-list-title">{property.name}</span>
+                      <span>{property.value}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </IconCard>
         ))}
         {!filtered.length ? <p className="empty">Aucun sort ne correspond à la recherche actuelle.</p> : null}
       </div>

--- a/frontend/src/components/WeaponPanel.tsx
+++ b/frontend/src/components/WeaponPanel.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import type { WeaponItem } from '../types'
 import { Panel } from './Panel'
+import { IconCard } from './IconCard'
+import { getIconUrl } from '../utils/icons'
 
 interface WeaponPanelProps {
   weapons: WeaponItem[]
@@ -52,35 +54,92 @@ export function WeaponPanel({ weapons }: WeaponPanelProps) {
           ))}
         </select>
       </div>
-      <div className="weapon-grid">
-        {filtered.map((item) => (
-          <article key={item.weapon_id}>
-            <header>
-              <h4>{item.name}</h4>
-              <p>{item.type}</p>
-            </header>
-            <p className="weapon-grid__rarity">{item.rarity}</p>
-            {item.damages.length ? (
-              <ul className="weapon-grid__damage">
-                {item.damages.slice(0, 2).map((damage, index) => (
-                  <li key={`${item.weapon_id}-damage-${index}`}>
-                    {damage.damage_dice} {damage.damage_type} {damage.modifier ? `(${damage.modifier})` : ''}
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-            {item.actions.length ? (
-              <ul className="weapon-grid__actions">
-                {item.actions.slice(0, 1).map((action) => (
-                  <li key={action.name}>
-                    <strong>{action.name} :</strong> {action.description}
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-            {item.locations.length ? <p className="weapon-grid__location">{item.locations[0].description}</p> : null}
-          </article>
-        ))}
+      <div className="icon-grid weapon-grid">
+        {filtered.map((item) => {
+          const damages = item.damages.slice(0, 3)
+          const actions = item.actions.slice(0, 2)
+          const abilities = item.abilities.slice(0, 2)
+          const location = item.locations[0]?.description
+
+          return (
+            <IconCard key={item.weapon_id} name={item.name} iconUrl={getIconUrl('weapon', item.name)}>
+              <div className="icon-grid__tooltip-meta">
+                {item.type ? (
+                  <span>
+                    <strong>Type :</strong> {item.type}
+                  </span>
+                ) : null}
+                {item.rarity ? (
+                  <span>
+                    <strong>Rareté :</strong> {item.rarity}
+                  </span>
+                ) : null}
+                {item.enchantment ? (
+                  <span>
+                    <strong>Enchantement :</strong> +{item.enchantment}
+                  </span>
+                ) : null}
+                {item.attributes ? (
+                  <span>
+                    <strong>Attributs :</strong> {item.attributes}
+                  </span>
+                ) : null}
+              </div>
+              {item.description ? (
+                <p className="icon-grid__tooltip-description">{item.description}</p>
+              ) : null}
+              {damages.length ? (
+                <div className="icon-grid__tooltip-section">
+                  <strong>Dégâts</strong>
+                  <ul className="icon-grid__tooltip-list">
+                    {damages.map((damage, index) => (
+                      <li key={`${item.weapon_id}-damage-${index}`}>
+                        <span className="icon-grid__tooltip-list-title">
+                          {damage.damage_type ?? '—'}
+                        </span>
+                        <span>
+                          {damage.damage_dice ?? '—'} {damage.modifier ? `(${damage.modifier})` : ''}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {actions.length ? (
+                <div className="icon-grid__tooltip-section">
+                  <strong>Actions</strong>
+                  <ul className="icon-grid__tooltip-list">
+                    {actions.map((action) => (
+                      <li key={action.name}>
+                        <span className="icon-grid__tooltip-list-title">{action.name}</span>
+                        {action.description ? <span>{action.description}</span> : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {abilities.length ? (
+                <div className="icon-grid__tooltip-section">
+                  <strong>Propriétés</strong>
+                  <ul className="icon-grid__tooltip-list">
+                    {abilities.map((ability) => (
+                      <li key={ability.name}>
+                        <span className="icon-grid__tooltip-list-title">{ability.name}</span>
+                        {ability.description ? <span>{ability.description}</span> : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {location ? (
+                <div className="icon-grid__tooltip-section">
+                  <strong>Obtention</strong>
+                  <p>{location}</p>
+                </div>
+              ) : null}
+            </IconCard>
+          )
+        })}
         {!filtered.length ? <p className="empty">Aucune arme ne correspond à la recherche.</p> : null}
       </div>
     </Panel>

--- a/frontend/src/utils/icons.ts
+++ b/frontend/src/utils/icons.ts
@@ -1,0 +1,101 @@
+function normalizeName(value: string) {
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
+function createIconMap(glob: Record<string, unknown>) {
+  const map = new Map<string, string>()
+  for (const [filePath, url] of Object.entries(glob)) {
+    if (typeof url !== 'string') continue
+    const segments = filePath.split('/')
+    const fileWithExtension = segments[segments.length - 1] ?? filePath
+    const fileName = fileWithExtension.replace(/\.[^/.]+$/, '')
+    const key = normalizeName(fileName)
+    if (!map.has(key)) {
+      map.set(key, url)
+    }
+  }
+  return map
+}
+
+const weaponIcons = import.meta
+  .glob('../../ressources/icons/weapon_images/*.png', { eager: true, import: 'default' })
+const armourIcons = import.meta
+  .glob('../../ressources/icons/armour_images/*.png', { eager: true, import: 'default' })
+const shieldIcons = import.meta
+  .glob('../../ressources/icons/shield_images/*.png', { eager: true, import: 'default' })
+const clothingIcons = import.meta
+  .glob('../../ressources/icons/clothing_images/*.png', { eager: true, import: 'default' })
+const headwearIcons = import.meta
+  .glob('../../ressources/icons/headwear_images/*.png', { eager: true, import: 'default' })
+const handwearIcons = import.meta
+  .glob('../../ressources/icons/handwear_images/*.png', { eager: true, import: 'default' })
+const footwearIcons = import.meta
+  .glob('../../ressources/icons/footwear_images/*.png', { eager: true, import: 'default' })
+const cloakIcons = import.meta
+  .glob('../../ressources/icons/cloak_images/*.png', { eager: true, import: 'default' })
+const ringIcons = import.meta
+  .glob('../../ressources/icons/ring_images/*.png', { eager: true, import: 'default' })
+const amuletIcons = import.meta
+  .glob('../../ressources/icons/amulet_images/*.png', { eager: true, import: 'default' })
+const spellIcons = import.meta
+  .glob('../../ressources/icons/spell_images/*.png', { eager: true, import: 'default' })
+const abilityIcons = import.meta
+  .glob('../../ressources/icons/ability_images/*.png', { eager: true, import: 'default' })
+const classIcons = import.meta
+  .glob('../../ressources/icons/class_images/*.png', { eager: true, import: 'default' })
+const raceIcons = import.meta
+  .glob('../../ressources/icons/race_images/*.png', { eager: true, import: 'default' })
+const backgroundIcons = import.meta
+  .glob('../../ressources/icons/background_images/*.png', { eager: true, import: 'default' })
+
+type IconCategory =
+  | 'weapon'
+  | 'armour'
+  | 'shield'
+  | 'clothing'
+  | 'headwear'
+  | 'handwear'
+  | 'footwear'
+  | 'cloak'
+  | 'ring'
+  | 'amulet'
+  | 'spell'
+  | 'ability'
+  | 'class'
+  | 'race'
+  | 'background'
+
+type IconMap = Record<IconCategory, Map<string, string>>
+
+const iconMaps: IconMap = {
+  weapon: createIconMap(weaponIcons),
+  armour: createIconMap(armourIcons),
+  shield: createIconMap(shieldIcons),
+  clothing: createIconMap(clothingIcons),
+  headwear: createIconMap(headwearIcons),
+  handwear: createIconMap(handwearIcons),
+  footwear: createIconMap(footwearIcons),
+  cloak: createIconMap(cloakIcons),
+  ring: createIconMap(ringIcons),
+  amulet: createIconMap(amuletIcons),
+  spell: createIconMap(spellIcons),
+  ability: createIconMap(abilityIcons),
+  class: createIconMap(classIcons),
+  race: createIconMap(raceIcons),
+  background: createIconMap(backgroundIcons),
+}
+
+export function getIconUrl(category: IconCategory, name: string | null | undefined) {
+  if (!name) return null
+  const normalized = normalizeName(name)
+  const iconMap = iconMaps[category]
+  return iconMap.get(normalized) ?? null
+}
+
+export { normalizeName }
+export type { IconCategory }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -12,6 +12,7 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "types": ["node"],
 
     /* Linting */
     "strict": true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const resourcesDir = path.resolve(fileURLToPath(new URL('../ressources', import.meta.url)))
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    fs: {
+      allow: [resourcesDir],
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- load item icons from the shared ressources directory and expose a reusable IconCard tooltip component
- render weapons, armours, accessories and spells as icon grids with hover/focus tooltips instead of text-heavy cards
- style the new gallery layout and ensure Vite can serve the external icon assets while adding Node typings

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c921bd89fc832b8a1cd70d7a91dd9f