### PR TITLE
Fix Vite FS allow list for frontend

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,13 +4,14 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const resourcesDir = path.resolve(fileURLToPath(new URL('../ressources', import.meta.url)))
+const frontendDir = fileURLToPath(new URL('.', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
     fs: {
-      allow: [resourcesDir],
+      allow: [frontendDir, resourcesDir],
     },
   },
 })


### PR DESCRIPTION
## Summary
- allow the Vite dev server to access the frontend directory along with shared resources

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c92794c8ac832b94ac88c003e54b7f