### PR TITLE
Fix tooltip layering and icon asset paths

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -934,6 +934,7 @@ button:hover {
   text-align: center;
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
   outline: none;
+  z-index: 0;
 }
 
 .icon-grid__item:hover,
@@ -941,6 +942,7 @@ button:hover {
   transform: translateY(-2px);
   border-color: rgba(140, 103, 70, 0.5);
   box-shadow: 0 10px 18px rgba(140, 103, 70, 0.18);
+  z-index: 40;
 }
 
 .icon-grid__item:focus-visible {
@@ -996,7 +998,7 @@ button:hover {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.18s ease, transform 0.18s ease;
-  z-index: 30;
+  z-index: 100;
   overflow-y: auto;
 }
 

--- a/frontend/src/utils/icons.ts
+++ b/frontend/src/utils/icons.ts
@@ -23,35 +23,35 @@ function createIconMap(glob: Record<string, unknown>) {
 }
 
 const weaponIcons = import.meta
-  .glob('../../ressources/icons/weapon_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/weapon_images/*.png', { eager: true, import: 'default' })
 const armourIcons = import.meta
-  .glob('../../ressources/icons/armour_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/armour_images/*.png', { eager: true, import: 'default' })
 const shieldIcons = import.meta
-  .glob('../../ressources/icons/shield_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/shield_images/*.png', { eager: true, import: 'default' })
 const clothingIcons = import.meta
-  .glob('../../ressources/icons/clothing_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/clothing_images/*.png', { eager: true, import: 'default' })
 const headwearIcons = import.meta
-  .glob('../../ressources/icons/headwear_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/headwear_images/*.png', { eager: true, import: 'default' })
 const handwearIcons = import.meta
-  .glob('../../ressources/icons/handwear_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/handwear_images/*.png', { eager: true, import: 'default' })
 const footwearIcons = import.meta
-  .glob('../../ressources/icons/footwear_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/footwear_images/*.png', { eager: true, import: 'default' })
 const cloakIcons = import.meta
-  .glob('../../ressources/icons/cloak_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/cloak_images/*.png', { eager: true, import: 'default' })
 const ringIcons = import.meta
-  .glob('../../ressources/icons/ring_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/ring_images/*.png', { eager: true, import: 'default' })
 const amuletIcons = import.meta
-  .glob('../../ressources/icons/amulet_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/amulet_images/*.png', { eager: true, import: 'default' })
 const spellIcons = import.meta
-  .glob('../../ressources/icons/spell_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/spell_images/*.png', { eager: true, import: 'default' })
 const abilityIcons = import.meta
-  .glob('../../ressources/icons/ability_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/ability_images/*.png', { eager: true, import: 'default' })
 const classIcons = import.meta
-  .glob('../../ressources/icons/class_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/class_images/*.png', { eager: true, import: 'default' })
 const raceIcons = import.meta
-  .glob('../../ressources/icons/race_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/race_images/*.png', { eager: true, import: 'default' })
 const backgroundIcons = import.meta
-  .glob('../../ressources/icons/background_images/*.png', { eager: true, import: 'default' })
+  .glob('../../../ressources/icons/background_images/*.png', { eager: true, import: 'default' })
 
 type IconCategory =
   | 'weapon'


### PR DESCRIPTION
## Summary
- raise hovered icon cards and tooltips so they render above neighbouring content
- point the icon glob imports to the repository ressources/icons directory so images load

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c92d4ccb58832ba6bd846e5b170c17