### PR TITLE
Add icons and detailed tooltips to character sheet

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -620,6 +620,27 @@ button:hover {
   font-style: italic;
 }
 
+.equipment-slot__card {
+  display: flex;
+  justify-content: center;
+}
+
+.equipment-slot__card .icon-grid__item {
+  width: 100%;
+  max-width: 150px;
+  padding: 0.65rem 0.55rem 0.85rem;
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.equipment-slot__card .icon-grid__image {
+  width: 60px;
+  height: 60px;
+}
+
+.equipment-slot__card .icon-grid__label {
+  font-size: 0.82rem;
+}
+
 .equipment-slot--headwear {
   grid-area: head;
 }
@@ -849,26 +870,8 @@ button:hover {
   border: 1px solid rgba(59, 73, 92, 0.2);
 }
 
-.spell-list {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.spell-list article {
-  border: 1px solid rgba(59, 73, 92, 0.2);
-  border-radius: 10px;
-  padding: 0.6rem 0.75rem;
-  background: rgba(248, 244, 232, 0.9);
-}
-
-.spell-list__name {
-  font-weight: 700;
-  letter-spacing: 0.05em;
-}
-
-.spell-list__level {
-  font-size: 0.85rem;
-  color: rgba(59, 73, 92, 0.75);
+.character-sheet__spell-grid {
+  margin-top: 0.75rem;
 }
 
 .character-sheet__notes-block {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -180,16 +180,21 @@ function App() {
   const races = useMemo(() => racesQuery.data ?? [], [racesQuery.data])
   const classes = useMemo(() => classesQuery.data ?? [], [classesQuery.data])
 
-  const weaponNames = useMemo(() => weapons.map((weapon) => weapon.name), [weapons])
-  const armourNames = useMemo(() => armours.map((armour) => armour.name), [armours])
-  const shieldNames = useMemo(() => shields.map((shield) => shield.name), [shields])
-  const headwearNames = useMemo(() => headwears.map((item) => item.name), [headwears])
-  const handwearNames = useMemo(() => handwears.map((item) => item.name), [handwears])
-  const footwearNames = useMemo(() => footwears.map((item) => item.name), [footwears])
-  const cloakNames = useMemo(() => cloaks.map((item) => item.name), [cloaks])
-  const amuletNames = useMemo(() => amulets.map((item) => item.name), [amulets])
-  const ringNames = useMemo(() => rings.map((item) => item.name), [rings])
-  const clothingNames = useMemo(() => clothing.map((item) => item.name), [clothing])
+  const equipmentCollections = useMemo(
+    () => ({
+      armours,
+      weapons,
+      shields,
+      clothing,
+      headwears,
+      handwears,
+      footwears,
+      cloaks,
+      rings,
+      amulets,
+    }),
+    [armours, weapons, shields, clothing, headwears, handwears, footwears, cloaks, rings, amulets],
+  )
 
   return (
     <div className="app">
@@ -224,16 +229,7 @@ function App() {
               races={races}
               classes={classes}
               spells={spells}
-              weaponOptions={weaponNames}
-              armourOptions={armourNames}
-              shieldOptions={shieldNames}
-              headwearOptions={headwearNames}
-              handwearOptions={handwearNames}
-              footwearOptions={footwearNames}
-              cloakOptions={cloakNames}
-              amuletOptions={amuletNames}
-              ringOptions={ringNames}
-              clothingOptions={clothingNames}
+              equipment={equipmentCollections}
             />
           </div>
 

--- a/frontend/src/components/CharacterSheet.tsx
+++ b/frontend/src/components/CharacterSheet.tsx
@@ -1,5 +1,23 @@
-import type { AbilityScoreKey, Build, CharacterClass, PartyMember, Race, Spell } from '../types'
+import { useMemo, type ReactNode } from 'react'
+import type {
+  AbilityScoreKey,
+  ArmourItem,
+  Build,
+  CharacterClass,
+  EquipmentCollections,
+  EquipmentSlotKey,
+  PartyMember,
+  Race,
+  Spell,
+  WeaponItem,
+  ShieldItem,
+  AccessoryItemBase,
+  ClothingItem,
+  FootwearItem,
+} from '../types'
 import { equipmentSlotLabels, equipmentSlotOrder } from '../utils/equipment'
+import { getIconUrl, normalizeName, type IconCategory } from '../utils/icons'
+import { IconCard } from './IconCard'
 import { Panel } from './Panel'
 
 interface CharacterSheetProps {
@@ -8,6 +26,7 @@ interface CharacterSheetProps {
   raceInfo: Race | undefined
   classInfo: CharacterClass | undefined
   spells: Spell[]
+  equipmentData: EquipmentCollections
 }
 
 const abilityOrder: { key: AbilityScoreKey; label: string }[] = [
@@ -19,12 +38,380 @@ const abilityOrder: { key: AbilityScoreKey; label: string }[] = [
   { key: 'Charisma', label: 'Charisme' },
 ]
 
+type EquipmentEntry =
+  | { category: 'armour'; item: ArmourItem }
+  | { category: 'weapon'; item: WeaponItem }
+  | { category: 'shield'; item: ShieldItem }
+  | { category: 'clothing'; item: ClothingItem }
+  | { category: 'footwear'; item: FootwearItem }
+  | { category: 'ring'; item: AccessoryItemBase }
+  | { category: 'amulet'; item: AccessoryItemBase }
+  | { category: 'cloak'; item: AccessoryItemBase }
+  | { category: 'handwear'; item: AccessoryItemBase }
+  | { category: 'headwear'; item: AccessoryItemBase }
+
+const slotCategories: Record<EquipmentSlotKey, IconCategory[]> = {
+  headwear: ['headwear'],
+  amulet: ['amulet'],
+  cloak: ['cloak'],
+  armour: ['armour'],
+  handwear: ['handwear'],
+  footwear: ['footwear'],
+  ring1: ['ring'],
+  ring2: ['ring'],
+  clothing: ['clothing'],
+  mainHand: ['weapon'],
+  offHand: ['shield', 'weapon'],
+  ranged: ['weapon'],
+}
+
+function addEquipmentEntry(map: Map<string, EquipmentEntry[]>, entry: EquipmentEntry) {
+  const key = normalizeName(entry.item.name)
+  if (!key) return
+  const existing = map.get(key)
+  if (existing) {
+    existing.push(entry)
+  } else {
+    map.set(key, [entry])
+  }
+}
+
+function findEquipmentEntry(
+  lookup: Map<string, EquipmentEntry[]>,
+  slot: EquipmentSlotKey,
+  name: string,
+): EquipmentEntry | null {
+  const normalized = normalizeName(name)
+  if (!normalized) return null
+  const candidates = lookup.get(normalized)
+  if (!candidates?.length) return null
+  const categories = slotCategories[slot] ?? []
+  for (const category of categories) {
+    const match = candidates.find((entry) => entry.category === category)
+    if (match) return match
+  }
+  return candidates[0] ?? null
+}
+
+function resolveIconUrl(
+  name: string,
+  entry: EquipmentEntry | null,
+  preferredCategories: IconCategory[],
+) {
+  if (!name) return null
+  const categories = entry
+    ? [entry.category, ...preferredCategories.filter((category) => category !== entry.category)]
+    : preferredCategories
+  for (const category of categories) {
+    const url = getIconUrl(category, name)
+    if (url) return url
+  }
+  if (entry) {
+    const url = getIconUrl(entry.category, name)
+    if (url) return url
+  }
+  return null
+}
+
+function renderAccessoryTooltip(item: AccessoryItemBase, extras: ReactNode[] = []) {
+  const location = item.locations[0]?.description
+  const specials = item.specials.slice(0, 3)
+
+  return (
+    <>
+      <div className="icon-grid__tooltip-meta">
+        {item.type ? (
+          <span>
+            <strong>Type :</strong> {item.type}
+          </span>
+        ) : null}
+        {item.rarity ? (
+          <span>
+            <strong>Rareté :</strong> {item.rarity}
+          </span>
+        ) : null}
+        {extras.map((content, index) => (
+          <span key={index}>{content}</span>
+        ))}
+        {item.price_gp != null ? (
+          <span>
+            <strong>Prix :</strong> {item.price_gp} po
+          </span>
+        ) : null}
+      </div>
+      {item.description ? <p className="icon-grid__tooltip-description">{item.description}</p> : null}
+      {specials.length ? (
+        <div className="icon-grid__tooltip-section">
+          <strong>Effets</strong>
+          <ul className="icon-grid__tooltip-list">
+            {specials.map((special) => (
+              <li key={special.name}>
+                <span className="icon-grid__tooltip-list-title">{special.name}</span>
+                {special.effect ? <span>{special.effect}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {location ? (
+        <div className="icon-grid__tooltip-section">
+          <strong>Obtention</strong>
+          <p>{location}</p>
+        </div>
+      ) : null}
+      {item.quote ? <p className="icon-grid__tooltip-quote">{item.quote}</p> : null}
+    </>
+  )
+}
+
+function renderArmourTooltip(item: ArmourItem) {
+  const specials = item.specials.slice(0, 3)
+  const location = item.locations[0]?.description
+
+  return (
+    <>
+      <div className="icon-grid__tooltip-meta">
+        {item.type ? (
+          <span>
+            <strong>Type :</strong> {item.type}
+          </span>
+        ) : null}
+        {item.rarity ? (
+          <span>
+            <strong>Rareté :</strong> {item.rarity}
+          </span>
+        ) : null}
+        <span>
+          <strong>Classe d'armure :</strong> {item.armour_class_base ?? '—'}
+          {item.armour_class_modifier ? ` (${item.armour_class_modifier})` : ''}
+        </span>
+        {item.weight_kg != null ? (
+          <span>
+            <strong>Poids :</strong> {item.weight_kg} kg
+          </span>
+        ) : null}
+      </div>
+      {item.description ? <p className="icon-grid__tooltip-description">{item.description}</p> : null}
+      {specials.length ? (
+        <div className="icon-grid__tooltip-section">
+          <strong>Effets</strong>
+          <ul className="icon-grid__tooltip-list">
+            {specials.map((special) => (
+              <li key={special.name}>
+                <span className="icon-grid__tooltip-list-title">{special.name}</span>
+                {special.effect ? <span>{special.effect}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {location ? (
+        <div className="icon-grid__tooltip-section">
+          <strong>Obtention</strong>
+          <p>{location}</p>
+        </div>
+      ) : null}
+      {item.quote ? <p className="icon-grid__tooltip-quote">{item.quote}</p> : null}
+    </>
+  )
+}
+
+function renderWeaponTooltip(item: WeaponItem) {
+  const damages = item.damages.slice(0, 3)
+  const actions = item.actions.slice(0, 2)
+  const abilities = item.abilities.slice(0, 2)
+  const location = item.locations[0]?.description
+
+  return (
+    <>
+      <div className="icon-grid__tooltip-meta">
+        {item.type ? (
+          <span>
+            <strong>Type :</strong> {item.type}
+          </span>
+        ) : null}
+        {item.rarity ? (
+          <span>
+            <strong>Rareté :</strong> {item.rarity}
+          </span>
+        ) : null}
+        {item.enchantment ? (
+          <span>
+            <strong>Enchantement :</strong> +{item.enchantment}
+          </span>
+        ) : null}
+        {item.attributes ? (
+          <span>
+            <strong>Attributs :</strong> {item.attributes}
+          </span>
+        ) : null}
+      </div>
+      {item.description ? <p className="icon-grid__tooltip-description">{item.description}</p> : null}
+      {damages.length ? (
+        <div className="icon-grid__tooltip-section">
+          <strong>Dégâts</strong>
+          <ul className="icon-grid__tooltip-list">
+            {damages.map((damage, index) => (
+              <li key={`${item.weapon_id}-damage-${index}`}>
+                <span className="icon-grid__tooltip-list-title">{damage.damage_type ?? '—'}</span>
+                <span>
+                  {damage.damage_dice ?? '—'} {damage.modifier ? `(${damage.modifier})` : ''}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {actions.length ? (
+        <div className="icon-grid__tooltip-section">
+          <strong>Actions</strong>
+          <ul className="icon-grid__tooltip-list">
+            {actions.map((action) => (
+              <li key={action.name}>
+                <span className="icon-grid__tooltip-list-title">{action.name}</span>
+                {action.description ? <span>{action.description}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {abilities.length ? (
+        <div className="icon-grid__tooltip-section">
+          <strong>Propriétés</strong>
+          <ul className="icon-grid__tooltip-list">
+            {abilities.map((ability) => (
+              <li key={ability.name}>
+                <span className="icon-grid__tooltip-list-title">{ability.name}</span>
+                {ability.description ? <span>{ability.description}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {location ? (
+        <div className="icon-grid__tooltip-section">
+          <strong>Obtention</strong>
+          <p>{location}</p>
+        </div>
+      ) : null}
+    </>
+  )
+}
+
+function renderEquipmentTooltip(entry: EquipmentEntry) {
+  switch (entry.category) {
+    case 'armour':
+      return renderArmourTooltip(entry.item)
+    case 'weapon':
+      return renderWeaponTooltip(entry.item)
+    case 'shield':
+      return renderAccessoryTooltip(
+        entry.item,
+        entry.item.shield_class_base != null
+          ? [
+              <>
+                <strong>Classe de bouclier :</strong> {entry.item.shield_class_base}
+              </>,
+            ]
+          : [],
+      )
+    case 'clothing': {
+      const extras: ReactNode[] = []
+      if (entry.item.armour_class_base != null) {
+        extras.push(
+          <>
+            <strong>Classe d'armure :</strong> {entry.item.armour_class_base}
+            {entry.item.armour_class_modifier ? ` (${entry.item.armour_class_modifier})` : ''}
+          </>,
+        )
+      }
+      return renderAccessoryTooltip(entry.item, extras)
+    }
+    case 'footwear':
+      return renderAccessoryTooltip(
+        entry.item,
+        entry.item.required_proficiency
+          ? [
+              <>
+                <strong>Maîtrise requise :</strong> {entry.item.required_proficiency}
+              </>,
+            ]
+          : [],
+      )
+    default:
+      return renderAccessoryTooltip(entry.item)
+  }
+}
+
+function renderSpellTooltip(spell: Spell) {
+  const properties = spell.properties.slice(0, 4)
+
+  return (
+    <>
+      <div className="icon-grid__tooltip-meta">
+        {spell.level ? (
+          <span>
+            <strong>Niveau :</strong> {spell.level}
+          </span>
+        ) : null}
+      </div>
+      {spell.description ? <p className="icon-grid__tooltip-description">{spell.description}</p> : null}
+      {properties.length ? (
+        <div className="icon-grid__tooltip-section">
+          <strong>Effets</strong>
+          <ul className="icon-grid__tooltip-list">
+            {properties.map((property) => (
+              <li key={property.name}>
+                <span className="icon-grid__tooltip-list-title">{property.name}</span>
+                <span>{property.value}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </>
+  )
+}
+
 function abilityModifier(score: number | undefined) {
   if (score === undefined) return 0
   return Math.floor((score - 10) / 2)
 }
 
-export function CharacterSheet({ member, build, raceInfo, classInfo, spells }: CharacterSheetProps) {
+export function CharacterSheet({
+  member,
+  build,
+  raceInfo,
+  classInfo,
+  spells,
+  equipmentData,
+}: CharacterSheetProps) {
+  const equipmentLookup = useMemo(() => {
+    const map = new Map<string, EquipmentEntry[]>()
+    equipmentData.armours.forEach((item) => addEquipmentEntry(map, { category: 'armour', item }))
+    equipmentData.weapons.forEach((item) => addEquipmentEntry(map, { category: 'weapon', item }))
+    equipmentData.shields.forEach((item) => addEquipmentEntry(map, { category: 'shield', item }))
+    equipmentData.clothing.forEach((item) => addEquipmentEntry(map, { category: 'clothing', item }))
+    equipmentData.footwears.forEach((item) => addEquipmentEntry(map, { category: 'footwear', item }))
+    equipmentData.rings.forEach((item) => addEquipmentEntry(map, { category: 'ring', item }))
+    equipmentData.amulets.forEach((item) => addEquipmentEntry(map, { category: 'amulet', item }))
+    equipmentData.cloaks.forEach((item) => addEquipmentEntry(map, { category: 'cloak', item }))
+    equipmentData.handwears.forEach((item) => addEquipmentEntry(map, { category: 'handwear', item }))
+    equipmentData.headwears.forEach((item) => addEquipmentEntry(map, { category: 'headwear', item }))
+    return map
+  }, [
+    equipmentData.armours,
+    equipmentData.weapons,
+    equipmentData.shields,
+    equipmentData.clothing,
+    equipmentData.footwears,
+    equipmentData.rings,
+    equipmentData.amulets,
+    equipmentData.cloaks,
+    equipmentData.handwears,
+    equipmentData.headwears,
+  ])
+
   if (!member) {
     return (
       <Panel title="Fiche de personnage" subtitle="Sélectionnez un héros pour consulter ses détails">
@@ -34,7 +421,7 @@ export function CharacterSheet({ member, build, raceInfo, classInfo, spells }: C
   }
 
   const knownSpells = spells.filter((spell) => member.spells.includes(spell.name))
-  const equipment = member.equipment ?? {}
+  const gear = member.equipment ?? {}
   const nextLevel = Math.min(12, member.level + 1)
   const nextStep = build?.levels.find((level) => level.level === nextLevel)
 
@@ -152,13 +539,27 @@ export function CharacterSheet({ member, build, raceInfo, classInfo, spells }: C
             <span>{member.name}</span>
           </div>
           {equipmentSlotOrder.map((slot) => {
-            const value = equipment[slot]
+            const value = gear[slot]
+            const preferredCategories = slotCategories[slot] ?? []
+            const entry = value ? findEquipmentEntry(equipmentLookup, slot, value) : null
+            const iconUrl = value ? resolveIconUrl(value, entry, preferredCategories) : null
+
             return (
               <div key={slot} className={`equipment-slot equipment-slot--${slot} equipment-slot--read-only`}>
                 <span className="equipment-slot__label">{equipmentSlotLabels[slot]}</span>
-                <span className={value ? 'equipment-slot__value' : 'equipment-slot__value equipment-slot__value--empty'}>
-                  {value ?? '—'}
-                </span>
+                {value ? (
+                  <div className="equipment-slot__card">
+                    <IconCard name={value} iconUrl={iconUrl}>
+                      {entry ? (
+                        renderEquipmentTooltip(entry)
+                      ) : (
+                        <p className="icon-grid__tooltip-description">Détails indisponibles pour cet objet.</p>
+                      )}
+                    </IconCard>
+                  </div>
+                ) : (
+                  <span className="equipment-slot__value equipment-slot__value--empty">—</span>
+                )}
               </div>
             )
           })}
@@ -168,22 +569,11 @@ export function CharacterSheet({ member, build, raceInfo, classInfo, spells }: C
       <section className="character-sheet__spellbook">
         <h4>Grimoire</h4>
         {knownSpells.length ? (
-          <div className="spell-list">
+          <div className="icon-grid character-sheet__spell-grid">
             {knownSpells.map((spell) => (
-              <article key={spell.name}>
-                <header>
-                  <span className="spell-list__name">{spell.name}</span>
-                  {spell.level ? <span className="spell-list__level">Niv. {spell.level}</span> : null}
-                </header>
-                <p>{spell.description}</p>
-                <ul>
-                  {spell.properties.map((property) => (
-                    <li key={property.name}>
-                      <strong>{property.name} :</strong> {property.value}
-                    </li>
-                  ))}
-                </ul>
-              </article>
+              <IconCard key={spell.name} name={spell.name} iconUrl={getIconUrl('spell', spell.name)}>
+                {renderSpellTooltip(spell)}
+              </IconCard>
             ))}
           </div>
         ) : (

--- a/frontend/src/components/PartyPlanner.tsx
+++ b/frontend/src/components/PartyPlanner.tsx
@@ -5,6 +5,7 @@ import type {
   AbilityScoreKey,
   Build,
   CharacterClass,
+  EquipmentCollections,
   EquipmentSlotKey,
   PartyEquipment,
   PartyMember,
@@ -22,16 +23,7 @@ interface PartyPlannerProps {
   races: Race[]
   classes: CharacterClass[]
   spells: Spell[]
-  weaponOptions: string[]
-  armourOptions: string[]
-  shieldOptions: string[]
-  headwearOptions: string[]
-  handwearOptions: string[]
-  footwearOptions: string[]
-  cloakOptions: string[]
-  amuletOptions: string[]
-  ringOptions: string[]
-  clothingOptions: string[]
+  equipment: EquipmentCollections
 }
 
 const abilityKeys: AbilityScoreKey[] = [
@@ -232,17 +224,31 @@ export function PartyPlanner({
   races,
   classes,
   spells,
-  weaponOptions,
-  armourOptions,
-  shieldOptions,
-  headwearOptions,
-  handwearOptions,
-  footwearOptions,
-  cloakOptions,
-  amuletOptions,
-  ringOptions,
-  clothingOptions,
+  equipment,
 }: PartyPlannerProps) {
+  const {
+    armours,
+    weapons,
+    shields,
+    clothing,
+    headwears,
+    handwears,
+    footwears,
+    cloaks,
+    rings,
+    amulets,
+  } = equipment
+
+  const weaponOptions = useMemo(() => weapons.map((item) => item.name), [weapons])
+  const armourOptions = useMemo(() => armours.map((item) => item.name), [armours])
+  const shieldOptions = useMemo(() => shields.map((item) => item.name), [shields])
+  const headwearOptions = useMemo(() => headwears.map((item) => item.name), [headwears])
+  const handwearOptions = useMemo(() => handwears.map((item) => item.name), [handwears])
+  const footwearOptions = useMemo(() => footwears.map((item) => item.name), [footwears])
+  const cloakOptions = useMemo(() => cloaks.map((item) => item.name), [cloaks])
+  const amuletOptions = useMemo(() => amulets.map((item) => item.name), [amulets])
+  const ringOptions = useMemo(() => rings.map((item) => item.name), [rings])
+  const clothingOptions = useMemo(() => clothing.map((item) => item.name), [clothing])
   const [storedMembers, setMembers] = useLocalStorage<PartyMember[]>('bg3-companion-party', [])
   const members = useMemo(
     () => storedMembers.map((member) => sanitizeMember(member as PartyMemberInput)),
@@ -762,6 +768,7 @@ export function PartyPlanner({
         raceInfo={selectedRaceInfo}
         classInfo={selectedClassInfo}
         spells={spells}
+        equipmentData={equipment}
       />
     </div>
   )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -267,6 +267,19 @@ export type EquipmentSlotKey = (typeof equipmentSlotKeys)[number]
 
 export type PartyEquipment = Partial<Record<EquipmentSlotKey, string>>
 
+export interface EquipmentCollections {
+  armours: ArmourItem[]
+  weapons: WeaponItem[]
+  shields: ShieldItem[]
+  clothing: ClothingItem[]
+  headwears: HeadwearItem[]
+  handwears: HandwearItem[]
+  footwears: FootwearItem[]
+  cloaks: CloakItem[]
+  rings: RingItem[]
+  amulets: AmuletItem[]
+}
+
 export interface PartyMember {
   id: string
   name: string

--- a/frontend/src/utils/icons.ts
+++ b/frontend/src/utils/icons.ts
@@ -7,6 +7,74 @@ function normalizeName(value: string) {
     .replace(/(^-|-$)/g, '')
 }
 
+function safeDecode(value: string) {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+const suffixTokens = ['icon', 'spell', 'melee', 'ranged', 'faded', 'badge']
+
+const plusWordMap: Record<string, string> = {
+  one: '+1',
+  two: '+2',
+  three: '+3',
+  four: '+4',
+  five: '+5',
+  six: '+6',
+  seven: '+7',
+  eight: '+8',
+  nine: '+9',
+  ten: '+10',
+}
+
+function generateNameVariants(fileName: string) {
+  const variants = new Set<string>()
+  const queue = [fileName]
+
+  while (queue.length) {
+    const current = queue.pop()
+    if (!current) continue
+    if (variants.has(current)) continue
+
+    variants.add(current)
+
+    const decoded = safeDecode(current)
+    if (decoded !== current) queue.push(decoded)
+
+    const withoutPrefix = current.replace(/^\d+(?:px)?[-_]?/i, '')
+    if (withoutPrefix !== current) queue.push(withoutPrefix)
+
+    const withoutWebp = current.replace(/\.webp$/i, '')
+    if (withoutWebp !== current) queue.push(withoutWebp)
+
+    for (const token of suffixTokens) {
+      const pattern = new RegExp(`(?:^|[-_])${token}(?:[-_]?[0-9]+)?$`, 'i')
+      if (pattern.test(current)) {
+        const trimmed = current.replace(pattern, '').replace(/[-_]+$/, '')
+        if (trimmed && trimmed !== current) queue.push(trimmed)
+      }
+    }
+
+    const plusConverted = current.replace(
+      /Plus(One|Two|Three|Four|Five|Six|Seven|Eight|Nine|Ten)/gi,
+      (_, word: string) => ` ${plusWordMap[word.toLowerCase()] ?? ''}`.trimEnd(),
+    )
+    if (plusConverted !== current) queue.push(plusConverted)
+
+    const prefixNumberMatch = current.match(/^(?:\+)?(\d+)[-_](.+)$/)
+    if (prefixNumberMatch) {
+      const [, number, rest] = prefixNumberMatch
+      const reordered = `${rest} +${number}`
+      if (reordered !== current) queue.push(reordered)
+    }
+  }
+
+  return variants
+}
+
 function createIconMap(glob: Record<string, unknown>) {
   const map = new Map<string, string>()
   for (const [filePath, url] of Object.entries(glob)) {
@@ -14,9 +82,13 @@ function createIconMap(glob: Record<string, unknown>) {
     const segments = filePath.split('/')
     const fileWithExtension = segments[segments.length - 1] ?? filePath
     const fileName = fileWithExtension.replace(/\.[^/.]+$/, '')
-    const key = normalizeName(fileName)
-    if (!map.has(key)) {
-      map.set(key, url)
+    const variants = generateNameVariants(fileName)
+    for (const variant of variants) {
+      const key = normalizeName(variant)
+      if (!key) continue
+      if (!map.has(key)) {
+        map.set(key, url)
+      }
     }
   }
   return map


### PR DESCRIPTION
## Summary
- make icon resolution tolerant to prefixed and suffixed asset filenames so spell and gear images load
- render character equipment and spells with icon cards that surface description details on hover
- feed the character sheet with item collections and adjust styling to integrate the new cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c959f4de84832b91c0bd7c2e1673f1