### PR TITLE
Allow configuring data directory via BG3_DATA_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Les fichiers SQLite fournis dans `data/` contiennent :
 - `bg3_armours.db`, `bg3_weapons.db`, `bg3_spells.db`, `bg3_races.db`, `bg3_classes.db` : données encyclopédiques.
 - `bg3_companion.db` : espace d'écriture utilisé par l'application (builds, bestiaire, checklist de butin, etc.).
 
+Pour charger un autre répertoire que `data/`, définissez la variable d'environnement `BG3_DATA_DIR` avant de lancer l'API. Le chemin
+peut être absolu ou relatif à la racine du projet.
+
 ## Vérifications
 
 Des commandes simples permettent de valider les deux projets :

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,28 +1,39 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, Optional
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
-DATA_DIR = ROOT_DIR / "data"
+
+_data_dir_env = os.getenv("BG3_DATA_DIR", "data")
+BG3_DATA_DIR = Path(_data_dir_env).expanduser()
+if not BG3_DATA_DIR.is_absolute():
+    BG3_DATA_DIR = ROOT_DIR / BG3_DATA_DIR
+
+DATA_DIR = BG3_DATA_DIR
+
+DATABASE_FILENAMES: Dict[str, str] = {
+    "companion": "bg3_companion.db",
+    "armours": "bg3_armours.db",
+    "weapons": "bg3_weapons.db",
+    "spells": "bg3_spells.db",
+    "races": "bg3_races.db",
+    "classes": "bg3_classes.db",
+    "rings": "bg3_rings.db",
+    "amulets": "bg3_amulets.db",
+    "cloaks": "bg3_cloaks.db",
+    "clothing": "bg3_clothing.db",
+    "footwears": "bg3_footwears.db",
+    "handwears": "bg3_handwears.db",
+    "headwears": "bg3_headwears.db",
+    "shields": "bg3_shields.db",
+}
 
 DATABASE_PATHS: Dict[str, Path] = {
-    "companion": DATA_DIR / "bg3_companion.db",
-    "armours": DATA_DIR / "bg3_armours.db",
-    "weapons": DATA_DIR / "bg3_weapons.db",
-    "spells": DATA_DIR / "bg3_spells.db",
-    "races": DATA_DIR / "bg3_races.db",
-    "classes": DATA_DIR / "bg3_classes.db",
-    "rings": DATA_DIR / "bg3_rings.db",
-    "amulets": DATA_DIR / "bg3_amulets.db",
-    "cloaks": DATA_DIR / "bg3_cloaks.db",
-    "clothing": DATA_DIR / "bg3_clothing.db",
-    "footwears": DATA_DIR / "bg3_footwears.db",
-    "handwears": DATA_DIR / "bg3_handwears.db",
-    "headwears": DATA_DIR / "bg3_headwears.db",
-    "shields": DATA_DIR / "bg3_shields.db",
+    key: DATA_DIR / filename for key, filename in DATABASE_FILENAMES.items()
 }
 
 

--- a/backend/tests/test_database_paths.py
+++ b/backend/tests/test_database_paths.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from backend.app import database
+
+
+@pytest.mark.parametrize(
+    "db_key", ["companion", "armours", "shields"],
+)
+def test_database_paths_follow_env_variable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, db_key: str
+) -> None:
+    monkeypatch.setenv("BG3_DATA_DIR", str(tmp_path))
+    try:
+        reloaded = importlib.reload(database)
+        expected = tmp_path / reloaded.DATABASE_FILENAMES[db_key]
+        assert reloaded.DATABASE_PATHS[db_key] == expected
+    finally:
+        monkeypatch.delenv("BG3_DATA_DIR", raising=False)
+        importlib.reload(database)


### PR DESCRIPTION
## Summary
- allow configuring the backend data directory via the `BG3_DATA_DIR` environment variable and derive database paths dynamically
- document the new configuration option in the README
- add automated coverage ensuring `BG3_DATA_DIR` influences the resolved database locations

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68c96bb1a1d4832b8e1e9867599cf2aa