### PR TITLE
Add CRUD tests for builds endpoint

### DIFF
--- a/backend/tests/test_builds.py
+++ b/backend/tests/test_builds.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+
+def _prepare_build_tables(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("DROP TABLE IF EXISTS build_levels")
+        conn.execute("DROP TABLE IF EXISTS builds")
+        conn.execute(
+            """
+            CREATE TABLE builds (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                race TEXT,
+                class TEXT,
+                subclass TEXT,
+                notes TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE build_levels (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                build_id INTEGER NOT NULL,
+                level INTEGER NOT NULL,
+                spells TEXT,
+                feats TEXT,
+                subclass_choice TEXT,
+                multiclass_choice TEXT,
+                FOREIGN KEY(build_id) REFERENCES builds(id)
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_create_build_creates_entry_with_levels(
+    client: TestClient, test_db: Path
+) -> None:
+    _prepare_build_tables(test_db)
+
+    payload = {
+        "name": "Arcane Archer",
+        "race": "Elf",
+        "class": "Fighter",
+        "subclass": "Arcane Archer",
+        "notes": "Ranged build focusing on archery.",
+        "levels": [
+            {
+                "level": 1,
+                "spells": "Magic Missile",
+                "feats": "Sharpshooter",
+                "subclass_choice": "Arcane Shot",
+                "multiclass_choice": "",
+            },
+            {
+                "level": 2,
+                "spells": "",
+                "feats": "Action Surge",
+                "subclass_choice": "",
+                "multiclass_choice": "",
+            },
+        ],
+    }
+
+    response = client.post("/api/builds", json=payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["id"] > 0
+    assert data["name"] == payload["name"]
+    assert data["class"] == payload["class"]
+    assert data["notes"] == payload["notes"]
+    assert len(data["levels"]) == 2
+
+    first_level = data["levels"][0]
+    assert first_level["level"] == 1
+    assert first_level["spells"] == "Magic Missile"
+    assert first_level["feats"] == "Sharpshooter"
+
+    list_response = client.get("/api/builds")
+    assert list_response.status_code == 200
+    builds = list_response.json()
+    assert len(builds) == 1
+    assert builds[0]["id"] == data["id"]
+
+
+def test_update_build_replaces_levels(client: TestClient, test_db: Path) -> None:
+    _prepare_build_tables(test_db)
+
+    create_payload = {
+        "name": "Arcane Archer",
+        "race": "Elf",
+        "class": "Fighter",
+        "subclass": "Arcane Archer",
+        "notes": "Ranged build focusing on archery.",
+        "levels": [
+            {
+                "level": 1,
+                "spells": "Magic Missile",
+                "feats": "Sharpshooter",
+                "subclass_choice": "Arcane Shot",
+                "multiclass_choice": "",
+            }
+        ],
+    }
+
+    create_response = client.post("/api/builds", json=create_payload)
+    assert create_response.status_code == 201
+    build_id = create_response.json()["id"]
+
+    update_levels: list[dict[str, Any]] = [
+        {
+            "level": 1,
+            "spells": "Hunter's Mark",
+            "feats": "Sharpshooter",
+            "subclass_choice": "Arcane Shot",
+            "multiclass_choice": "",
+        },
+        {
+            "level": 2,
+            "spells": "",
+            "feats": "Action Surge",
+            "subclass_choice": "",
+            "multiclass_choice": "",
+        },
+    ]
+    update_payload = {
+        "name": "Arcane Archer",
+        "race": "Elf",
+        "class": "Fighter",
+        "subclass": "Arcane Archer",
+        "notes": "Updated notes.",
+        "levels": update_levels,
+    }
+
+    response = client.put(f"/api/builds/{build_id}", json=update_payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["id"] == build_id
+    assert data["notes"] == "Updated notes."
+    assert len(data["levels"]) == 2
+    returned_spells = [level["spells"] for level in data["levels"]]
+    assert "Hunter's Mark" in returned_spells
+    assert "Magic Missile" not in returned_spells
+
+    detail_response = client.get(f"/api/builds/{build_id}")
+    assert detail_response.status_code == 200
+    detail = detail_response.json()
+    assert len(detail["levels"]) == 2
+    assert detail["levels"][0]["spells"] == "Hunter's Mark"
+
+
+def test_delete_build_removes_entry(client: TestClient, test_db: Path) -> None:
+    _prepare_build_tables(test_db)
+
+    payload = {
+        "name": "Arcane Archer",
+        "race": "Elf",
+        "class": "Fighter",
+        "subclass": "Arcane Archer",
+        "notes": "Ranged build focusing on archery.",
+        "levels": [
+            {
+                "level": 1,
+                "spells": "Magic Missile",
+                "feats": "Sharpshooter",
+                "subclass_choice": "Arcane Shot",
+                "multiclass_choice": "",
+            }
+        ],
+    }
+
+    create_response = client.post("/api/builds", json=payload)
+    assert create_response.status_code == 201
+    build_id = create_response.json()["id"]
+
+    delete_response = client.delete(f"/api/builds/{build_id}")
+    assert delete_response.status_code == 204
+
+    list_response = client.get("/api/builds")
+    assert list_response.status_code == 200
+    assert list_response.json() == []
+
+    detail_response = client.get(f"/api/builds/{build_id}")
+    assert detail_response.status_code == 404
+
+
+def test_update_build_missing_returns_404(client: TestClient, test_db: Path) -> None:
+    _prepare_build_tables(test_db)
+
+    payload = {
+        "name": "Arcane Archer",
+        "race": "Elf",
+        "class": "Fighter",
+        "subclass": "Arcane Archer",
+        "notes": "Ranged build focusing on archery.",
+        "levels": [],
+    }
+
+    response = client.put("/api/builds/999", json=payload)
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Build not found"


### PR DESCRIPTION
## Summary
- add end-to-end tests for the builds API covering creation, update, deletion, and 404 scenarios
- prepare in-memory schema for builds tables within the tests to exercise database-backed CRUD flows

## Testing
- python -m pytest backend/tests/test_builds.py

------
https://chatgpt.com/codex/tasks/task_e_68c97040b9d8832bb26e7c5c7ec0952e