### PR TITLE
Add build level notes and improve spell filters

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,7 +42,7 @@ def _load_build(build_id: int) -> schemas.Build:
         raise HTTPException(status_code=404, detail="Build not found")
     level_rows = fetch_all(
         "companion",
-        "SELECT id, level, spells, feats, subclass_choice, multiclass_choice FROM build_levels WHERE build_id = ? ORDER BY level",
+        "SELECT id, level, spells, feats, subclass_choice, multiclass_choice, note FROM build_levels WHERE build_id = ? ORDER BY level",
         (build_id,),
     )
     levels = [
@@ -53,6 +53,7 @@ def _load_build(build_id: int) -> schemas.Build:
             feats=row.get("feats") or "",
             subclass_choice=row.get("subclass_choice") or "",
             multiclass_choice=row.get("multiclass_choice") or "",
+            note=row.get("note") or "",
         )
         for row in level_rows
     ]
@@ -181,7 +182,7 @@ def list_builds() -> List[schemas.Build]:
     level_rows = fetch_all(
         "companion",
         f"""
-        SELECT build_id, id, level, spells, feats, subclass_choice, multiclass_choice
+        SELECT build_id, id, level, spells, feats, subclass_choice, multiclass_choice, note
         FROM build_levels
         WHERE build_id IN ({placeholders})
         ORDER BY level
@@ -198,6 +199,7 @@ def list_builds() -> List[schemas.Build]:
                 feats=row.get("feats") or "",
                 subclass_choice=row.get("subclass_choice") or "",
                 multiclass_choice=row.get("multiclass_choice") or "",
+                note=row.get("note") or "",
             )
         )
 
@@ -251,8 +253,8 @@ def create_build(payload: schemas.BuildCreate) -> schemas.Build:
             execute(
                 "companion",
                 """
-                INSERT INTO build_levels (build_id, level, spells, feats, subclass_choice, multiclass_choice)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO build_levels (build_id, level, spells, feats, subclass_choice, multiclass_choice, note)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     new_id,
@@ -261,6 +263,7 @@ def create_build(payload: schemas.BuildCreate) -> schemas.Build:
                     level.feats or "",
                     level.subclass_choice or "",
                     level.multiclass_choice or "",
+                    level.note or "",
                 ),
             )
         except sqlite3.Error as exc:
@@ -315,8 +318,8 @@ def update_build(build_id: int, payload: schemas.BuildCreate) -> schemas.Build:
             execute(
                 "companion",
                 """
-                INSERT INTO build_levels (build_id, level, spells, feats, subclass_choice, multiclass_choice)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO build_levels (build_id, level, spells, feats, subclass_choice, multiclass_choice, note)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     build_id,
@@ -325,6 +328,7 @@ def update_build(build_id: int, payload: schemas.BuildCreate) -> schemas.Build:
                     level.feats or "",
                     level.subclass_choice or "",
                     level.multiclass_choice or "",
+                    level.note or "",
                 ),
             )
         except sqlite3.Error as exc:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -37,6 +37,7 @@ class BuildLevelBase(BaseModel):
     feats: Optional[str] = ""
     subclass_choice: Optional[str] = ""
     multiclass_choice: Optional[str] = ""
+    note: Optional[str] = ""
 
 
 class BuildLevelCreate(BuildLevelBase):

--- a/backend/tests/test_builds.py
+++ b/backend/tests/test_builds.py
@@ -35,6 +35,7 @@ def _prepare_build_tables(db_path: Path) -> None:
                 feats TEXT,
                 subclass_choice TEXT,
                 multiclass_choice TEXT,
+                note TEXT,
                 FOREIGN KEY(build_id) REFERENCES builds(id)
             )
             """
@@ -62,6 +63,7 @@ def test_create_build_creates_entry_with_levels(
                 "feats": "Sharpshooter",
                 "subclass_choice": "Arcane Shot",
                 "multiclass_choice": "",
+                "note": "Open with Magic Missile for consistent damage.",
             },
             {
                 "level": 2,
@@ -69,6 +71,7 @@ def test_create_build_creates_entry_with_levels(
                 "feats": "Action Surge",
                 "subclass_choice": "",
                 "multiclass_choice": "",
+                "note": "Action Surge enables burst turns.",
             },
         ],
     }
@@ -87,6 +90,7 @@ def test_create_build_creates_entry_with_levels(
     assert first_level["level"] == 1
     assert first_level["spells"] == "Magic Missile"
     assert first_level["feats"] == "Sharpshooter"
+    assert first_level["note"] == "Open with Magic Missile for consistent damage."
 
     list_response = client.get("/api/builds")
     assert list_response.status_code == 200
@@ -111,6 +115,7 @@ def test_update_build_replaces_levels(client: TestClient, test_db: Path) -> None
                 "feats": "Sharpshooter",
                 "subclass_choice": "Arcane Shot",
                 "multiclass_choice": "",
+                "note": "Initial loadout.",
             }
         ],
     }
@@ -126,6 +131,7 @@ def test_update_build_replaces_levels(client: TestClient, test_db: Path) -> None
             "feats": "Sharpshooter",
             "subclass_choice": "Arcane Shot",
             "multiclass_choice": "",
+            "note": "Swap to Hunter's Mark for extra damage.",
         },
         {
             "level": 2,
@@ -133,6 +139,7 @@ def test_update_build_replaces_levels(client: TestClient, test_db: Path) -> None
             "feats": "Action Surge",
             "subclass_choice": "",
             "multiclass_choice": "",
+            "note": "Leverage Action Surge in key fights.",
         },
     ]
     update_payload = {
@@ -154,6 +161,8 @@ def test_update_build_replaces_levels(client: TestClient, test_db: Path) -> None
     returned_spells = [level["spells"] for level in data["levels"]]
     assert "Hunter's Mark" in returned_spells
     assert "Magic Missile" not in returned_spells
+    notes = [level["note"] for level in data["levels"]]
+    assert any("Hunter's Mark" in note or "extra damage" in note for note in notes)
 
     detail_response = client.get(f"/api/builds/{build_id}")
     assert detail_response.status_code == 200
@@ -178,6 +187,7 @@ def test_delete_build_removes_entry(client: TestClient, test_db: Path) -> None:
                 "feats": "Sharpshooter",
                 "subclass_choice": "Arcane Shot",
                 "multiclass_choice": "",
+                "note": "Initial loadout.",
             }
         ],
     }

--- a/backend/tests/test_builds_error_handling.py
+++ b/backend/tests/test_builds_error_handling.py
@@ -22,6 +22,7 @@ LEVEL_PAYLOAD = {
     "feats": "",
     "subclass_choice": "",
     "multiclass_choice": "",
+    "note": "",
 }
 
 

--- a/frontend/src/components/BuildLibrary.tsx
+++ b/frontend/src/components/BuildLibrary.tsx
@@ -17,6 +17,7 @@ const emptyLevel: BuildLevel = {
   feats: '',
   subclass_choice: '',
   multiclass_choice: '',
+  note: '',
 }
 
 export function BuildLibrary({ builds, onCreate, onUpdate, onDelete }: BuildLibraryProps) {
@@ -47,6 +48,7 @@ export function BuildLibrary({ builds, onCreate, onUpdate, onDelete }: BuildLibr
           feats: entry.feats?.trim() ?? '',
           subclass_choice: entry.subclass_choice?.trim() ?? '',
           multiclass_choice: entry.multiclass_choice?.trim() ?? '',
+          note: entry.note?.trim() ?? '',
         }))
         .sort((a, b) => a.level - b.level),
     }
@@ -66,7 +68,9 @@ export function BuildLibrary({ builds, onCreate, onUpdate, onDelete }: BuildLibr
       class_name: build.class_name ?? '',
       subclass: build.subclass ?? '',
       notes: build.notes ?? '',
-      levels: build.levels.length ? build.levels.map((level) => ({ ...level })) : [{ ...emptyLevel }],
+      levels: build.levels.length
+        ? build.levels.map((level) => ({ ...level, note: level.note ?? '' }))
+        : [{ ...emptyLevel }],
     })
     setSelectedId(build.id)
     setIsEditing(true)
@@ -222,6 +226,14 @@ export function BuildLibrary({ builds, onCreate, onUpdate, onDelete }: BuildLibr
                           multiclass_choice: event.target.value,
                         })
                       }
+                    />
+                  </label>
+                  <label>
+                    Note
+                    <textarea
+                      rows={2}
+                      value={level.note ?? ''}
+                      onChange={(event) => updateLevel(index, { note: event.target.value })}
                     />
                   </label>
                   <button type="button" className="link link--danger" onClick={() => removeLevel(index)}>

--- a/frontend/src/components/CharacterSheet.tsx
+++ b/frontend/src/components/CharacterSheet.tsx
@@ -17,6 +17,7 @@ import type {
 } from '../types'
 import { equipmentSlotLabels, equipmentSlotOrder } from '../utils/equipment'
 import { getIconUrl, normalizeName, type IconCategory } from '../utils/icons'
+import { getSpellLevelLabel, sortSpellsByLevel } from '../utils/spells'
 import { IconCard } from './IconCard'
 import { Panel } from './Panel'
 
@@ -345,13 +346,15 @@ function renderEquipmentTooltip(entry: EquipmentEntry) {
 
 function renderSpellTooltip(spell: Spell) {
   const properties = spell.properties.slice(0, 4)
+  const levelLabel = getSpellLevelLabel(spell.level)
+  const levelTitle = levelLabel === 'Cantrips' ? 'Type :' : 'Niveau :'
 
   return (
     <>
       <div className="icon-grid__tooltip-meta">
-        {spell.level ? (
+        {levelLabel ? (
           <span>
-            <strong>Niveau :</strong> {spell.level}
+            <strong>{levelTitle}</strong> {levelLabel}
           </span>
         ) : null}
       </div>
@@ -412,6 +415,11 @@ export function CharacterSheet({
     equipmentData.headwears,
   ])
 
+  const knownSpells = useMemo(
+    () => (member ? spells.filter((spell) => member.spells.includes(spell.name)).sort(sortSpellsByLevel) : []),
+    [spells, member],
+  )
+
   if (!member) {
     return (
       <Panel title="Fiche de personnage" subtitle="Sélectionnez un héros pour consulter ses détails">
@@ -419,8 +427,6 @@ export function CharacterSheet({
       </Panel>
     )
   }
-
-  const knownSpells = spells.filter((spell) => member.spells.includes(spell.name))
   const gear = member.equipment ?? {}
   const nextLevel = Math.min(12, member.level + 1)
   const nextStep = build?.levels.find((level) => level.level === nextLevel)
@@ -489,6 +495,11 @@ export function CharacterSheet({
                     <strong>Choix spéciaux :</strong>{' '}
                     {nextStep.subclass_choice || nextStep.multiclass_choice || '—'}
                   </p>
+                  {nextStep.note ? (
+                    <p>
+                      <strong>Note :</strong> {nextStep.note}
+                    </p>
+                  ) : null}
                 </div>
               ) : (
                 <p className="character-sheet__notes">Ce build couvre jusqu'au niveau {build.levels.at(-1)?.level ?? ''}.</p>
@@ -517,14 +528,6 @@ export function CharacterSheet({
           </ul>
         </div>
         <div>
-          <h4>Jets de sauvegarde</h4>
-          <ul className="tag-list">
-            {member.savingThrows.length ? (
-              member.savingThrows.map((save) => <li key={save}>{save}</li>)
-            ) : (
-              <li className="empty">Aucun bonus renseigné</li>
-            )}
-          </ul>
           <h4>Compétences</h4>
           <ul className="tag-list">
             {member.skills.length ? member.skills.map((skill) => <li key={skill}>{skill}</li>) : <li className="empty">—</li>}

--- a/frontend/src/components/SpellLibrary.tsx
+++ b/frontend/src/components/SpellLibrary.tsx
@@ -3,22 +3,43 @@ import type { Spell } from '../types'
 import { Panel } from './Panel'
 import { IconCard } from './IconCard'
 import { getIconUrl } from '../utils/icons'
+import { getNormalizedSpellLevel, getSpellLevelLabel, sortSpellsByLevel } from '../utils/spells'
 
 interface SpellLibraryProps {
   spells: Spell[]
 }
 
-const levels = ['0', '1', '2', '3', '4', '5', '6']
-
 export function SpellLibrary({ spells }: SpellLibraryProps) {
   const [search, setSearch] = useState('')
   const [level, setLevel] = useState('')
 
+  const levelOptions = useMemo(() => {
+    const labelMap = new Map<string, string>()
+    spells.forEach((spell) => {
+      const value = getNormalizedSpellLevel(spell.level)
+      if (!value) return
+      if (!labelMap.has(value)) {
+        labelMap.set(value, getSpellLevelLabel(spell.level) ?? `Niveau ${value}`)
+      }
+    })
+    return Array.from(labelMap.entries())
+      .sort((a, b) => {
+        const aNum = Number.parseInt(a[0], 10)
+        const bNum = Number.parseInt(b[0], 10)
+        if (Number.isNaN(aNum) || Number.isNaN(bNum)) {
+          return a[1].localeCompare(b[1], 'fr')
+        }
+        return aNum - bNum
+      })
+      .map(([value, label]) => ({ value, label }))
+  }, [spells])
+
   const filtered = useMemo(() => {
-    const lower = search.toLowerCase()
+    const lower = search.trim().toLowerCase()
     return spells
-      .filter((spell) => (level ? spell.level === level : true))
+      .filter((spell) => (level ? getNormalizedSpellLevel(spell.level) === level : true))
       .filter((spell) => (lower ? spell.name.toLowerCase().includes(lower) : true))
+      .sort(sortSpellsByLevel)
       .slice(0, 30)
   }, [spells, search, level])
 
@@ -33,41 +54,45 @@ export function SpellLibrary({ spells }: SpellLibraryProps) {
         />
         <select value={level} onChange={(event) => setLevel(event.target.value)}>
           <option value="">Tous les niveaux</option>
-          {levels.map((lvl) => (
-            <option key={lvl} value={lvl}>
-              Niveau {lvl}
+          {levelOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
             </option>
           ))}
         </select>
       </div>
       <div className="icon-grid spell-library">
-        {filtered.map((spell) => (
-          <IconCard key={spell.name} name={spell.name} iconUrl={getIconUrl('spell', spell.name)}>
-            <div className="icon-grid__tooltip-meta">
-              {spell.level ? (
-                <span>
-                  <strong>Niveau :</strong> {spell.level}
-                </span>
-              ) : null}
-            </div>
-            {spell.description ? (
-              <p className="icon-grid__tooltip-description">{spell.description}</p>
-            ) : null}
-            {spell.properties.length ? (
-              <div className="icon-grid__tooltip-section">
-                <strong>Propriétés</strong>
-                <ul className="icon-grid__tooltip-list">
-                  {spell.properties.slice(0, 4).map((property) => (
-                    <li key={property.name}>
-                      <span className="icon-grid__tooltip-list-title">{property.name}</span>
-                      <span>{property.value}</span>
-                    </li>
-                  ))}
-                </ul>
+        {filtered.map((spell) => {
+          const levelLabel = getSpellLevelLabel(spell.level)
+          const levelTitle = levelLabel === 'Cantrips' ? 'Type :' : 'Niveau :'
+          return (
+            <IconCard key={spell.name} name={spell.name} iconUrl={getIconUrl('spell', spell.name)}>
+              <div className="icon-grid__tooltip-meta">
+                {levelLabel ? (
+                  <span>
+                    <strong>{levelTitle}</strong> {levelLabel}
+                  </span>
+                ) : null}
               </div>
-            ) : null}
-          </IconCard>
-        ))}
+              {spell.description ? (
+                <p className="icon-grid__tooltip-description">{spell.description}</p>
+              ) : null}
+              {spell.properties.length ? (
+                <div className="icon-grid__tooltip-section">
+                  <strong>Propriétés</strong>
+                  <ul className="icon-grid__tooltip-list">
+                    {spell.properties.slice(0, 4).map((property) => (
+                      <li key={property.name}>
+                        <span className="icon-grid__tooltip-list-title">{property.name}</span>
+                        <span>{property.value}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </IconCard>
+          )
+        })}
         {!filtered.length ? <p className="empty">Aucun sort ne correspond à la recherche actuelle.</p> : null}
       </div>
     </Panel>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,6 +14,7 @@ export interface BuildLevel {
   feats?: string | null
   subclass_choice?: string | null
   multiclass_choice?: string | null
+  note?: string | null
 }
 
 export interface Build {
@@ -291,7 +292,6 @@ export interface PartyMember {
   level: number
   buildId?: number
   abilityScores: Record<AbilityScoreKey, number>
-  savingThrows: AbilityScoreKey[]
   skills: string[]
   equipment?: PartyEquipment
   spells: string[]

--- a/frontend/src/utils/spells.ts
+++ b/frontend/src/utils/spells.ts
@@ -1,0 +1,59 @@
+import type { Spell } from '../types'
+
+export interface SpellLevelInfo {
+  value: string
+  label: string
+  shortLabel: string
+}
+
+const CANTRIP_REGEX = /^cantrips?$/i
+const DIGIT_REGEX = /([0-9]+)/
+
+export function getSpellLevelInfo(level?: string | null): SpellLevelInfo | null {
+  if (!level) return null
+  const trimmed = level.trim()
+  if (!trimmed) return null
+  if (CANTRIP_REGEX.test(trimmed)) {
+    return {
+      value: '0',
+      label: 'Cantrips',
+      shortLabel: 'Cantrip',
+    }
+  }
+  const match = trimmed.match(DIGIT_REGEX)
+  if (match) {
+    const numeric = match[1]
+    return {
+      value: numeric,
+      label: `Niveau ${numeric}`,
+      shortLabel: `Niv. ${numeric}`,
+    }
+  }
+  const fallback = trimmed
+  return {
+    value: fallback.toLowerCase(),
+    label: fallback,
+    shortLabel: fallback,
+  }
+}
+
+export function getNormalizedSpellLevel(level?: string | null): string | null {
+  const info = getSpellLevelInfo(level)
+  return info?.value ?? null
+}
+
+export function getSpellLevelLabel(level?: string | null): string | null {
+  const info = getSpellLevelInfo(level)
+  return info?.label ?? null
+}
+
+export function getSpellLevelShortLabel(level?: string | null): string | null {
+  const info = getSpellLevelInfo(level)
+  return info?.shortLabel ?? null
+}
+
+export function sortSpellsByLevel(spellA: Spell, spellB: Spell): number {
+  const levelA = Number.parseInt(getNormalizedSpellLevel(spellA.level) ?? '99', 10)
+  const levelB = Number.parseInt(getNormalizedSpellLevel(spellB.level) ?? '99', 10)
+  return levelA - levelB || spellA.name.localeCompare(spellB.name, 'fr')
+}


### PR DESCRIPTION
## Summary
- add editable notes to each build level and persist them through the API and character sheet
- remove saving throw handling from the party planner and character sheet
- normalize spell levels so filtering works and level 0 spells are labeled Cantrips
- restore the bg3_companion database to its previous version so no binary diff remains

## Testing
- pytest
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68c9836527bc832b8b3382ac0c757e0c