### PR TITLE
Fix frontend API base URL fallback for dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ VITE_API_BASE_URL="http://localhost:8000"
 
 Adaptez l'URL si l'API est exposée sur une autre machine ou un autre port.
 
+Si la variable n'est pas définie, le front tente automatiquement de contacter l'API
+sur le même hôte en supposant le port `8000` lorsque l'application est lancée avec
+`npm run dev` ou `npm run preview`. Cette valeur par défaut facilite le
+démarrage local, mais pensez à définir `VITE_API_BASE_URL` si votre API tourne
+sur un autre port ou une autre machine.
+
 ## Scripts npm utiles
 
 Depuis `frontend/` :


### PR DESCRIPTION
## Summary
- ensure the API client falls back to the backend on port 8000 when running via the Vite dev/preview server without VITE_API_BASE_URL
- document the new default so local setups understand how the automatic fallback works

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99c4d06a0832b8062bcfcdeec18ce