### PR TITLE
Fix tooltip hover hitbox

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1005,7 +1005,7 @@ button:hover {
   padding: 0.9rem;
   box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
   opacity: 0;
-  pointer-events: auto;
+  pointer-events: none;
   transition: opacity 0.18s ease, transform 0.18s ease;
   z-index: 100;
   overflow-y: auto;
@@ -1036,6 +1036,7 @@ button:hover {
 .icon-grid__item:focus-visible .icon-grid__tooltip {
   opacity: 1;
   transform: translate(-50%, 0);
+  pointer-events: auto;
 }
 
 .icon-grid__tooltip-content {


### PR DESCRIPTION
## Summary
- prevent hidden tooltips from intercepting hover by disabling pointer events until visible
- re-enable pointer events for active tooltips so users can interact with their content

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9c8c87c3c832bad8b76dbfa24ba65