### PR TITLE
Fix equipment layout and tooltip display

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -876,8 +876,9 @@ button:focus-visible {
 
 .icon-grid__tooltip {
   position: absolute;
-  inset: auto auto 1rem 50%;
-  transform: translateX(-50%) translateY(10px);
+  top: calc(100% + 0.75rem);
+  left: 50%;
+  transform: translate(-50%, -8px);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease;
@@ -895,7 +896,7 @@ button:focus-visible {
 .icon-grid__item:focus-visible .icon-grid__tooltip,
 .icon-grid__item:hover .icon-grid__tooltip {
   opacity: 1;
-  transform: translateX(-50%) translateY(0);
+  transform: translate(-50%, 0);
 }
 
 .icon-grid__tooltip-content {
@@ -1018,7 +1019,8 @@ button:focus-visible {
     'character armour armour armour'
     'character handwear ring1 ring2'
     'character handwear mainHand offHand'
-    'character footwear clothing clothing';
+    'character footwear clothing clothing'
+    'character ranged ranged ranged';
   padding: 1.5rem;
   border-radius: 24px;
   background: rgba(12, 23, 42, 0.7);

--- a/frontend/src/components/panel.css
+++ b/frontend/src/components/panel.css
@@ -9,13 +9,14 @@
   gap: 1.2rem;
   backdrop-filter: blur(calc(var(--blur-strength) * 0.55));
   box-shadow: 0 22px 45px rgba(4, 10, 30, 0.45);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .panel::before {
   content: '';
   position: absolute;
   inset: 0;
+  border-radius: inherit;
   background: linear-gradient(120deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- ensure the equipment grid reserves space for the ranged slot so items stay in place
- reposition equipment tooltips beneath the card and let panels allow them to overflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d62e5094832b81bb89bf754736e0