### PR TITLE
Fix bestiary overflow and center equipment layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -959,8 +959,14 @@ button:focus-visible {
 
 .bestiary {
   display: grid;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
   gap: 1.25rem;
+  align-items: start;
+}
+
+.bestiary__list,
+.bestiary__details {
+  min-width: 0;
 }
 
 .bestiary__list ul {
@@ -993,8 +999,15 @@ button:focus-visible {
   gap: 0.55rem;
 }
 
+.bestiary__details {
+  display: grid;
+  gap: 1.1rem;
+  align-content: start;
+}
+
 .enemy-card,
 .enemy-form {
+  width: 100%;
   background: rgba(12, 23, 42, 0.74);
   border-radius: 22px;
   border: 1px solid rgba(148, 163, 184, 0.18);
@@ -1013,18 +1026,19 @@ button:focus-visible {
   position: relative;
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(140px, 1fr));
   grid-template-areas:
-    'head head amulet cloak'
-    'character armour armour armour'
-    'character handwear ring1 ring2'
-    'character handwear mainHand offHand'
-    'character footwear clothing clothing'
-    'character ranged ranged ranged';
+    'head character cloak'
+    'armour character amulet'
+    'handwear character ring1'
+    'footwear character ring2'
+    'mainHand character offHand'
+    'ranged character clothing';
   padding: 1.5rem;
   border-radius: 24px;
   background: rgba(12, 23, 42, 0.7);
   border: 1px solid rgba(148, 163, 184, 0.18);
+  align-items: start;
 }
 
 .equipment-layout--sheet {
@@ -1042,9 +1056,10 @@ button:focus-visible {
 
 .equipment-layout__character {
   grid-area: character;
-  width: 160px;
-  height: 220px;
-  margin: 0 auto;
+  justify-self: center;
+  align-self: center;
+  width: min(100%, 220px);
+  aspect-ratio: 2 / 3;
   border-radius: 18px;
   border: 1px solid rgba(148, 163, 184, 0.18);
   background: radial-gradient(circle at 50% 35%, rgba(245, 194, 102, 0.22), rgba(12, 23, 42, 0.7));
@@ -1064,6 +1079,7 @@ button:focus-visible {
   background: rgba(16, 28, 52, 0.68);
   border: 1px solid rgba(148, 163, 184, 0.18);
   min-height: 120px;
+  height: 100%;
 }
 
 .equipment-slot--read-only {
@@ -1174,14 +1190,18 @@ button:focus-visible {
   }
 
   .equipment-layout {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(120px, 1fr));
     grid-template-areas:
-      'head head amulet'
-      'cloak character ring1'
-      'armour character ring2'
-      'handwear character offHand'
-      'footwear mainHand ranged'
-      'clothing clothing ranged';
+      'head character cloak'
+      'armour character amulet'
+      'handwear character ring1'
+      'footwear character ring2'
+      'mainHand character offHand'
+      'ranged character clothing';
+  }
+
+  .equipment-layout__character {
+    width: min(100%, 200px);
   }
 }
 
@@ -1198,18 +1218,19 @@ button:focus-visible {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-areas:
       'head character'
-      'amulet character'
-      'cloak mainHand'
-      'armour offHand'
-      'handwear ranged'
-      'footwear ranged'
-      'ring1 clothing'
-      'ring2 clothing';
+      'armour character'
+      'handwear character'
+      'footwear character'
+      'mainHand character'
+      'offHand character'
+      'ranged character'
+      'cloak amulet'
+      'ring1 ring2'
+      'clothing clothing';
   }
 
   .equipment-layout__character {
-    width: 140px;
-    height: 190px;
+    width: min(100%, 160px);
   }
 
   .icon-grid {


### PR DESCRIPTION
## Summary
- adjust the bestiary grid layout so the list and details stay inside the panel and form fills the available width
- realign the equipment layout around the character with symmetrical columns and consistent slot sizing
- update responsive breakpoints and character card sizing to keep the arrangement centered on smaller screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d93b6fa4832bbd99541ec8d98be7