### PR TITLE
Stack bestiary list above details

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -958,10 +958,10 @@ button:focus-visible {
 }
 
 .bestiary {
-  display: grid;
-  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
   gap: 1.25rem;
-  align-items: start;
+  align-items: stretch;
 }
 
 .bestiary__list,
@@ -1169,8 +1169,7 @@ button:focus-visible {
     grid-column: auto;
   }
 
-  .party-planner__layout,
-  .bestiary {
+  .party-planner__layout {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- stack the bestiary panel vertically so the list renders above the detail view
- remove the obsolete grid override in the responsive rules now that the panel uses flex layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9e5c5d798832ba6e7a8480a2eb866