### PR TITLE
Reduce equipment icon footprint

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1073,12 +1073,12 @@ button:focus-visible {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
-  padding: 0.85rem 1rem;
+  gap: 0.45rem;
+  padding: 0.75rem 0.85rem;
   border-radius: 18px;
   background: rgba(16, 28, 52, 0.68);
   border: 1px solid rgba(148, 163, 184, 0.18);
-  min-height: 120px;
+  min-height: 0;
   height: 100%;
 }
 
@@ -1097,6 +1097,22 @@ button:focus-visible {
   display: grid;
   gap: 0.35rem;
   color: var(--color-text-secondary);
+}
+
+.equipment-slot .icon-grid__item {
+  gap: 0.35rem;
+  padding: 0.65rem 0.55rem;
+  border-radius: 16px;
+}
+
+.equipment-slot .icon-grid__image {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+}
+
+.equipment-slot .icon-grid__label {
+  font-size: 0.85rem;
 }
 
 .equipment-slot__value {


### PR DESCRIPTION
## Summary
- halve the icon size inside equipment slots and tighten the IconCard padding so gear occupies less space
- let equipment slots shrink naturally by removing the large minimum height to make the full loadout visible without scrolling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9e60cff0c832b8d57670b7b0b62f3