### PR TITLE
Move bestiary search into panel body

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -964,6 +964,16 @@ button:focus-visible {
   align-items: stretch;
 }
 
+.bestiary__controls {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.bestiary__controls input {
+  width: 100%;
+  max-width: 320px;
+}
+
 .bestiary__list,
 .bestiary__details {
   min-width: 0;

--- a/frontend/src/components/BestiaryPanel.tsx
+++ b/frontend/src/components/BestiaryPanel.tsx
@@ -92,20 +92,16 @@ export function BestiaryPanel({ enemies, onCreate, onUpdate, onDelete }: Bestiar
   }
 
   return (
-    <Panel
-      title="Bestiaire"
-      subtitle="Préparez-vous face aux menaces majeures"
-      collapsible
-      actions={
-        <input
-          type="search"
-          placeholder="Rechercher un ennemi"
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-        />
-      }
-    >
+    <Panel title="Bestiaire" subtitle="Préparez-vous face aux menaces majeures" collapsible>
       <div className="bestiary">
+        <div className="bestiary__controls">
+          <input
+            type="search"
+            placeholder="Rechercher un ennemi"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+        </div>
         <div className="bestiary__list">
           <ul>
             {filteredEnemies.map((enemy) => (


### PR DESCRIPTION
## Summary
- move the bestiary search input into the panel content so it sits within the box
- add local styling to keep the field aligned with the panel layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9e6f9eec8832bbdcaae140eff19a2