### PR TITLE
Use dropdowns for build race and class fields

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -285,6 +285,8 @@ function App() {
           <div className="app__column">
             <BuildLibrary
               builds={builds}
+              races={races}
+              classes={classes}
               onCreate={handleCreateBuild}
               onUpdate={handleUpdateBuild}
               onDelete={handleDeleteBuild}


### PR DESCRIPTION
## Summary
- replace the free text fields in the build editor with dropdowns backed by the race and class catalogues
- show subclasses filtered by the selected class while keeping a fallback entry for existing custom values
- pass the race and class datasets from the app down to the build editor component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9e8938c9c832b9f7f8c4ce953b481