### PR TITLE
Handle trailing qualifiers in icon normalization

### DIFF
--- a/frontend/src/utils/icons.ts
+++ b/frontend/src/utils/icons.ts
@@ -1,5 +1,9 @@
+const trailingQualifierPattern = /(?:\s*(?:\([^)]*\)|\[[^\]]*\]))+$/g
+
 function normalizeName(value: string) {
   return value
+    .trim()
+    .replace(trailingQualifierPattern, '')
     .toLowerCase()
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')


### PR DESCRIPTION
## Summary
- strip trailing parenthetical or bracketed qualifiers before normalizing icon names
- ensure names like "Resistance (Cantrip)" resolve to the same keys as base icon files

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9ea4fb4ac832b8716bf6ccd5bb2ce