### PR TITLE
Hide build creation form behind toggle button

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -423,6 +423,12 @@ button:focus-visible {
   gap: 1.2rem;
 }
 
+.build-library__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
 .build-library__list ul {
   list-style: none;
   margin: 0;
@@ -430,6 +436,10 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
+}
+
+.build-library__new {
+  align-self: flex-start;
 }
 
 .build-library__list li {


### PR DESCRIPTION
## Summary
- hide the build creation form until users click the new “+ Nouveau build” button
- show the form when editing a build and reset it after saving or removing the selected entry
- add layout styles and an empty-state message for the build library when the form is hidden

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9eda14154832b98a1d9647f82768f