### PR TITLE
Stack character skills below ability scores

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -726,8 +726,8 @@ button:focus-visible {
 }
 
 .character-sheet__stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 1.1rem;
 }
 


### PR DESCRIPTION
## Summary
- ensure the character sheet skills list appears below the ability scores by switching the stats layout to a vertical stack

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9ee1b5b80832baf9528f6f0503bfd