### PR TITLE
Add close button to build creation form

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -480,6 +480,36 @@ button:focus-visible {
   box-shadow: 0 22px 45px rgba(4, 10, 30, 0.45);
 }
 
+.build-form__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.build-form__header h3 {
+  margin: 0;
+}
+
+.build-form__close {
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.25rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 150ms ease, background-color 150ms ease;
+}
+
+.build-form__close:hover,
+.build-form__close:focus-visible {
+  color: var(--color-text-primary);
+  background: rgba(148, 163, 184, 0.18);
+  outline: none;
+}
+
 .build-form__levels {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/BuildLibrary.tsx
+++ b/frontend/src/components/BuildLibrary.tsx
@@ -178,7 +178,17 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
                 void handleSubmit()
               }}
             >
-              <h3>{isEditing ? 'Modifier le build' : 'Créer un build'}</h3>
+              <div className="build-form__header">
+                <h3>{isEditing ? 'Modifier le build' : 'Créer un build'}</h3>
+                <button
+                  type="button"
+                  className="build-form__close"
+                  onClick={() => resetForm(true)}
+                  aria-label="Fermer le formulaire de build"
+                >
+                  ×
+                </button>
+              </div>
               <div className="form__row">
                 <label>
                   Nom du build


### PR DESCRIPTION
## Summary
- add a dismiss action to the build creation form so it can be closed without saving
- style the close control to match the existing build form layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f094df54832b990503b3640e36d7