### PR TITLE
Adjust ability grid and equipment icon sizes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -745,22 +745,21 @@ button:focus-visible {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
+  display: grid;
   gap: 0.6rem;
-  overflow-x: auto;
-  padding-bottom: 0.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
 }
 
 .ability-grid li {
   background: rgba(12, 23, 42, 0.7);
   border-radius: 16px;
-  padding: 0.75rem;
+  padding: 0.65rem;
   border: 1px solid rgba(148, 163, 184, 0.18);
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.25rem;
   align-items: center;
-  flex: 1 0 140px;
+  min-width: 0;
 }
 
 .ability-grid__label {
@@ -1130,9 +1129,9 @@ button:focus-visible {
 }
 
 .equipment-slot .icon-grid__image {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
 }
 
 .equipment-slot .icon-grid__label {


### PR DESCRIPTION
## Summary
- switch the Caractéristiques list to a responsive grid to remove the horizontal scrollbar
- slightly tighten the ability card padding to keep the layout compact
- shrink equipment slot icons for a less dominant appearance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9f137fa20832bb5d725cdfbfc94df