### PR TITLE
Increase padding for link-style buttons

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -283,7 +283,7 @@ button:focus-visible {
 .link {
   border: none;
   background: none;
-  padding: 0;
+  padding: 0.35rem 0.85rem;
   color: var(--color-accent);
   cursor: pointer;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- add padding to the `.link` button style so actions like Importer and Exporter have more breathing room

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f2097a0c832b90692d217ef326fe