### PR TITLE
Add space between party member name and class

### DIFF
--- a/frontend/src/components/PartyPlanner.tsx
+++ b/frontend/src/components/PartyPlanner.tsx
@@ -469,7 +469,7 @@ export function PartyPlanner({
               {members.map((member) => (
                 <li key={member.id} className={member.id === selectedId ? 'active' : ''}>
                   <button className="link" onClick={() => setSelectedId(member.id)}>
-                    <span className="party-planner__name">{member.name || 'Compagnon sans nom'}</span>
+                    <span className="party-planner__name">{member.name || 'Compagnon sans nom'}</span>{' '}
                     <span className="party-planner__meta">
                       {member.class_name ? `${member.class_name} · ` : ''}Niv. {member.level}
                     </span>


### PR DESCRIPTION
## Summary
- add a whitespace separator between the roster name and class metadata to improve readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f34453b4832baa1b7f6d1f42dcf4