### PR TITLE
Standardize icon grid card heights

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -915,6 +915,25 @@ button:focus-visible {
 .icon-grid__label {
   text-align: center;
   font-size: 0.95rem;
+  line-height: 1.25;
+  min-height: calc(1.25em * 3);
+  max-height: calc(1.25em * 3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.icon-grid__label-text {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow: hidden;
+  max-height: 100%;
+  width: 100%;
+  word-break: break-word;
+  text-overflow: ellipsis;
 }
 
 .icon-grid__tooltip {

--- a/frontend/src/components/IconCard.tsx
+++ b/frontend/src/components/IconCard.tsx
@@ -30,7 +30,9 @@ export function IconCard({ name, iconUrl, children }: IconCardProps) {
           </span>
         )}
       </div>
-      <span className="icon-grid__label">{name}</span>
+      <span className="icon-grid__label" title={name}>
+        <span className="icon-grid__label-text">{name}</span>
+      </span>
       {hasTooltip ? (
         <div className="icon-grid__tooltip" id={tooltipId} role="tooltip">
           <div className="icon-grid__tooltip-content">{children}</div>


### PR DESCRIPTION
## Summary
- clamp icon grid labels to three lines so every card in the grids keeps the same height
- wrap the icon label text in a dedicated span and expose the full name through the title attribute

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68c9f45e0e18832b8d8973f27f7e3544