### PR TITLE
Shrink icon card layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -870,8 +870,8 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.55rem;
-  padding: 1.1rem 0.75rem;
+  gap: 0.5rem;
+  padding: 0.95rem 0.65rem;
   border-radius: 20px;
   background: rgba(16, 28, 52, 0.68);
   border: 1px solid rgba(148, 163, 184, 0.16);
@@ -889,8 +889,8 @@ button:focus-visible {
 }
 
 .icon-grid__image {
-  width: 72px;
-  height: 72px;
+  width: 64px;
+  height: 64px;
   border-radius: 18px;
   overflow: hidden;
   background: rgba(10, 20, 36, 0.85);
@@ -914,10 +914,10 @@ button:focus-visible {
 
 .icon-grid__label {
   text-align: center;
-  font-size: 0.95rem;
-  line-height: 1.25;
-  min-height: calc(1.25em * 3);
-  max-height: calc(1.25em * 3);
+  font-size: 0.85rem;
+  line-height: 1.2;
+  min-height: calc(1.2em * 2);
+  max-height: calc(1.2em * 2);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -927,8 +927,8 @@ button:focus-visible {
 .icon-grid__label-text {
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  line-clamp: 3;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
   overflow: hidden;
   max-height: 100%;
   width: 100%;


### PR DESCRIPTION
## Summary
- decrease icon card padding and icon size to shrink overall footprint
- reduce label font size and clamp to two lines to keep text area compact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb32c481a4832bb1625536f3049847