### PR TITLE
Use database image paths for icons

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -511,6 +511,7 @@ def _list_equipment(
             "weight_kg": item.get("weight_kg"),
             "weight_lb": item.get("weight_lb"),
             "price_gp": item.get("price_gp"),
+            "image_path": item.get("image_path"),
             "locations": location_map.get(item["item_id"], []),
             "specials": special_map.get(item["item_id"], []),
         }
@@ -654,6 +655,7 @@ def list_weapons() -> List[schemas.Weapon]:
                 range_m=weapon.get("range_m"),
                 range_f=weapon.get("range_f"),
                 attributes=weapon.get("attributes"),
+                image_path=weapon.get("image_path"),
                 damages=damage_map.get(weapon["weapon_id"], []),
                 actions=action_map.get(weapon["weapon_id"], []),
                 abilities=ability_map.get(weapon["weapon_id"], []),
@@ -678,7 +680,7 @@ def list_spells() -> List[schemas.Spell]:
     spells = fetch_all(
         "spells",
         """
-        SELECT name, level, description
+        SELECT name, level, description, image_path
         FROM Spells
         ORDER BY name COLLATE NOCASE
         """,
@@ -704,6 +706,7 @@ def list_spells() -> List[schemas.Spell]:
             level=row.get("level"),
             school=_infer_spell_school(row.get("description")),
             description=row.get("description"),
+            image_path=row.get("image_path"),
             properties=prop_map.get(row["name"], []),
         )
         for row in spells

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -122,6 +122,7 @@ class Armour(BaseModel):
     weight_kg: Optional[float] = None
     weight_lb: Optional[float] = None
     price_gp: Optional[float] = None
+    image_path: Optional[str] = None
     armour_class_base: Optional[int] = None
     armour_class_modifier: Optional[str] = None
     locations: List[ArmourLocation] = Field(default_factory=list)
@@ -138,6 +139,7 @@ class AccessoryBase(BaseModel):
     weight_kg: Optional[float] = None
     weight_lb: Optional[float] = None
     price_gp: Optional[float] = None
+    image_path: Optional[str] = None
     locations: List[ArmourLocation] = Field(default_factory=list)
     specials: List[ArmourSpecial] = Field(default_factory=list)
 
@@ -216,6 +218,7 @@ class Weapon(BaseModel):
     range_m: Optional[float] = None
     range_f: Optional[float] = None
     attributes: Optional[str] = None
+    image_path: Optional[str] = None
     damages: List[WeaponDamage] = Field(default_factory=list)
     actions: List[WeaponAction] = Field(default_factory=list)
     abilities: List[WeaponAbility] = Field(default_factory=list)
@@ -233,6 +236,7 @@ class Spell(BaseModel):
     level: Optional[str] = None
     school: Optional[str] = None
     description: Optional[str] = None
+    image_path: Optional[str] = None
     properties: List[SpellProperty] = Field(default_factory=list)
 
 

--- a/backend/tests/test_spells.py
+++ b/backend/tests/test_spells.py
@@ -16,7 +16,8 @@ def spells_db(tmp_path, monkeypatch: pytest.MonkeyPatch):
             CREATE TABLE Spells (
                 name TEXT PRIMARY KEY,
                 level TEXT,
-                description TEXT
+                description TEXT,
+                image_path TEXT
             )
             """
         )
@@ -33,19 +34,21 @@ def spells_db(tmp_path, monkeypatch: pytest.MonkeyPatch):
         )
         conn.executemany(
             """
-            INSERT INTO Spells (name, level, description)
-            VALUES (?, ?, ?)
+            INSERT INTO Spells (name, level, description, image_path)
+            VALUES (?, ?, ?, ?)
             """,
             [
                 (
                     "Magic Missile",
                     "1",
                     "Magic Missile is a level 1 evocation spell that conjures bolts of magical force.",
+                    "spell_images/Magic_Missile.png",
                 ),
                 (
                     "Fireball",
                     "3",
                     "Fireball is a level 3 evocation spell that engulfs an area in roaring flames.",
+                    "spell_images/Fireball.png",
                 ),
             ],
         )
@@ -86,6 +89,7 @@ def test_list_spells_returns_spells_with_properties(spells_db, client):
     assert magic_missile["level"] == "1"
     assert magic_missile["school"] == "Evocation"
     assert "bolts of magical force" in (magic_missile.get("description") or "").lower()
+    assert magic_missile.get("image_path") == "spell_images/Magic_Missile.png"
     assert _properties_by_name(magic_missile) == {
         "Casting Time": "1 action",
         "Range": "120 feet",
@@ -95,6 +99,7 @@ def test_list_spells_returns_spells_with_properties(spells_db, client):
     assert fireball["level"] == "3"
     assert fireball["school"] == "Evocation"
     assert "roaring flames" in (fireball.get("description") or "").lower()
+    assert fireball.get("image_path") == "spell_images/Fireball.png"
     assert _properties_by_name(fireball) == {
         "Area": "20-foot-radius sphere",
         "Saving Throw": "DEX",

--- a/frontend/src/components/AccessoryPanel.tsx
+++ b/frontend/src/components/AccessoryPanel.tsx
@@ -96,7 +96,11 @@ export function AccessoryPanel<T extends AccessoryItemBase>({
           const extraDetail = renderDetails ? renderDetails(item) : null
 
           return (
-            <IconCard key={item.item_id} name={item.name} iconUrl={getIconUrl(iconCategory, item.name)}>
+            <IconCard
+              key={item.item_id}
+              name={item.name}
+              iconUrl={getIconUrl(iconCategory, item.name, item.image_path)}
+            >
               <div className="icon-grid__tooltip-meta">
                 {item.type ? (
                   <span>

--- a/frontend/src/components/ArmouryPanel.tsx
+++ b/frontend/src/components/ArmouryPanel.tsx
@@ -60,7 +60,11 @@ export function ArmouryPanel({ armours }: ArmouryPanelProps) {
           const location = item.locations[0]?.description
 
           return (
-            <IconCard key={item.item_id} name={item.name} iconUrl={getIconUrl('armour', item.name)}>
+            <IconCard
+              key={item.item_id}
+              name={item.name}
+              iconUrl={getIconUrl('armour', item.name, item.image_path)}
+            >
               <div className="icon-grid__tooltip-meta">
                 {item.type ? (
                   <span>

--- a/frontend/src/components/CharacterSheet.tsx
+++ b/frontend/src/components/CharacterSheet.tsx
@@ -99,18 +99,24 @@ function resolveIconUrl(
   entry: EquipmentEntry | null,
   preferredCategories: IconCategory[],
 ) {
-  if (!name) return null
   const categories = entry
     ? [entry.category, ...preferredCategories.filter((category) => category !== entry.category)]
     : preferredCategories
+
   for (const category of categories) {
-    const url = getIconUrl(category, name)
+    const url = getIconUrl(category, name, entry?.item.image_path)
     if (url) return url
+    if (entry && entry.item.name && entry.item.name !== name) {
+      const fallback = getIconUrl(category, entry.item.name, entry.item.image_path)
+      if (fallback) return fallback
+    }
   }
+
   if (entry) {
-    const url = getIconUrl(entry.category, name)
+    const url = getIconUrl(entry.category, entry.item.name, entry.item.image_path)
     if (url) return url
   }
+
   return null
 }
 
@@ -574,7 +580,11 @@ export function CharacterSheet({
         {knownSpells.length ? (
           <div className="icon-grid character-sheet__spell-grid">
             {knownSpells.map((spell) => (
-              <IconCard key={spell.name} name={spell.name} iconUrl={getIconUrl('spell', spell.name)}>
+            <IconCard
+              key={spell.name}
+              name={spell.name}
+              iconUrl={getIconUrl('spell', spell.name, spell.image_path)}
+            >
                 {renderSpellTooltip(spell)}
               </IconCard>
             ))}

--- a/frontend/src/components/SpellLibrary.tsx
+++ b/frontend/src/components/SpellLibrary.tsx
@@ -89,7 +89,11 @@ export function SpellLibrary({ spells }: SpellLibraryProps) {
           const levelLabel = getSpellLevelLabel(spell.level)
           const levelTitle = levelLabel === 'Cantrips' ? 'Type :' : 'Niveau :'
           return (
-            <IconCard key={spell.name} name={spell.name} iconUrl={getIconUrl('spell', spell.name)}>
+            <IconCard
+              key={spell.name}
+              name={spell.name}
+              iconUrl={getIconUrl('spell', spell.name, spell.image_path)}
+            >
               <div className="icon-grid__tooltip-meta">
                 {levelLabel ? (
                   <span>

--- a/frontend/src/components/WeaponPanel.tsx
+++ b/frontend/src/components/WeaponPanel.tsx
@@ -62,7 +62,11 @@ export function WeaponPanel({ weapons }: WeaponPanelProps) {
           const location = item.locations[0]?.description
 
           return (
-            <IconCard key={item.weapon_id} name={item.name} iconUrl={getIconUrl('weapon', item.name)}>
+            <IconCard
+              key={item.weapon_id}
+              name={item.name}
+              iconUrl={getIconUrl('weapon', item.name, item.image_path)}
+            >
               <div className="icon-grid__tooltip-meta">
                 {item.type ? (
                   <span>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -57,6 +57,7 @@ export interface ArmourItem {
   weight_kg?: number | null
   weight_lb?: number | null
   price_gp?: number | null
+  image_path?: string | null
   armour_class_base?: number | null
   armour_class_modifier?: string | null
   locations: ArmourLocation[]
@@ -76,6 +77,7 @@ export interface AccessoryItemBase {
   weight_kg?: number | null
   weight_lb?: number | null
   price_gp?: number | null
+  image_path?: string | null
   locations: AccessoryLocation[]
   specials: AccessorySpecial[]
 }
@@ -144,6 +146,7 @@ export interface WeaponItem {
   range_m?: number | null
   range_f?: number | null
   attributes?: string | null
+  image_path?: string | null
   damages: WeaponDamage[]
   actions: WeaponAction[]
   abilities: WeaponAbility[]
@@ -161,6 +164,7 @@ export interface Spell {
   level?: string | null
   school?: string | null
   description?: string | null
+  image_path?: string | null
   properties: SpellProperty[]
 }
 


### PR DESCRIPTION
## Summary
- expose the `image_path` column for equipment and spells through the API schemas and tests
- normalise icon resource paths so frontend lookups can resolve assets using database-provided paths
- pass image paths from panels and the character sheet to the icon helper to display the correct artwork

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb3692bcc4832bba6629ffd6cacf14