### PR TITLE
Fix equipment tooltips and ensure character sheet data loads

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -885,7 +885,7 @@ button:focus-visible {
 .icon-grid__item:hover {
   transform: translateY(-2px);
   box-shadow: 0 16px 32px rgba(5, 12, 30, 0.45);
-  z-index: 20;
+  z-index: 80;
 }
 
 .icon-grid__image {
@@ -952,7 +952,7 @@ button:focus-visible {
   box-shadow: 0 24px 40px rgba(4, 10, 30, 0.55);
   padding: 1rem 1.2rem;
   color: var(--color-text-secondary);
-  z-index: 10;
+  z-index: 60;
 }
 
 .icon-grid__item:focus-visible .icon-grid__tooltip,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,52 +55,42 @@ function App() {
   const armoursQuery = useQuery({
     queryKey: ['armours'],
     queryFn: async () => sortByName(await api.getArmours()),
-    enabled: false,
   })
   const ringsQuery = useQuery({
     queryKey: ['rings'],
     queryFn: async () => sortByName(await api.getRings()),
-    enabled: false,
   })
   const amuletsQuery = useQuery({
     queryKey: ['amulets'],
     queryFn: async () => sortByName(await api.getAmulets()),
-    enabled: false,
   })
   const cloaksQuery = useQuery({
     queryKey: ['cloaks'],
     queryFn: async () => sortByName(await api.getCloaks()),
-    enabled: false,
   })
   const clothingQuery = useQuery({
     queryKey: ['clothing'],
     queryFn: async () => sortByName(await api.getClothing()),
-    enabled: false,
   })
   const footwearsQuery = useQuery({
     queryKey: ['footwears'],
     queryFn: async () => sortByName(await api.getFootwears()),
-    enabled: false,
   })
   const handwearsQuery = useQuery({
     queryKey: ['handwears'],
     queryFn: async () => sortByName(await api.getHandwears()),
-    enabled: false,
   })
   const headwearsQuery = useQuery({
     queryKey: ['headwears'],
     queryFn: async () => sortByName(await api.getHeadwears()),
-    enabled: false,
   })
   const shieldsQuery = useQuery({
     queryKey: ['shields'],
     queryFn: async () => sortByName(await api.getShields()),
-    enabled: false,
   })
   const weaponsQuery = useQuery({
     queryKey: ['weapons'],
     queryFn: async () => sortByName(await api.getWeapons()),
-    enabled: false,
   })
   const spellsQuery = useQuery({
     queryKey: ['spells'],


### PR DESCRIPTION
## Summary
- fetch all equipment collections immediately so character sheet tooltips can find their data
- raise icon card stacking order so tooltips display above the equipment grid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb3c257f98832b802ea612444a96e5