### PR TITLE
Refactor build editor to surface class progression data

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -532,6 +532,161 @@ button:focus-visible {
   border: 1px solid rgba(148, 163, 184, 0.18);
 }
 
+.build-form__class-overview,
+.build-form__subclass-overview {
+  display: grid;
+  gap: 0.65rem;
+  padding: 1rem 1.15rem;
+  border-radius: 18px;
+  background: rgba(14, 25, 44, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.build-form__class-overview-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.build-form__class-overview h4,
+.build-form__subclass-overview h5 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-primary);
+}
+
+.build-form__class-description {
+  margin: 0.25rem 0 0;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+.build-form__class-details {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.build-form__class-details > div {
+  background: rgba(8, 16, 32, 0.55);
+  border-radius: 14px;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.build-form__class-details dt {
+  margin: 0 0 0.25rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.build-form__class-details dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.build-form__level-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.build-form__level-select {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 120px;
+}
+
+.build-form__level-stats {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 0;
+}
+
+.build-form__level-stats > div {
+  background: rgba(8, 16, 32, 0.48);
+  border-radius: 12px;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.build-form__level-stats dt {
+  margin: 0 0 0.15rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.build-form__level-stats dd {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.build-form__level-section {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.build-form__level-summary {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.build-form__hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.build-form__hint--muted {
+  color: var(--color-text-muted);
+}
+
+.build-form__feature-list {
+  list-style: none;
+  margin: 0.35rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.build-form__feature-list li {
+  background: rgba(8, 16, 32, 0.5);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.build-form__feature-list strong {
+  display: block;
+  color: var(--color-text-primary);
+  font-size: 0.95rem;
+}
+
+.build-form__feature-list p {
+  margin: 0.35rem 0 0;
+  color: var(--color-text-secondary);
+  line-height: 1.35;
+}
+
+.build-form__level-row {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
 .party-planner {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/BuildLibrary.tsx
+++ b/frontend/src/components/BuildLibrary.tsx
@@ -1,5 +1,12 @@
 import { useMemo, useState } from 'react'
-import type { Build, BuildLevel, CharacterClass, Race } from '../types'
+import type {
+  Build,
+  BuildLevel,
+  CharacterClass,
+  ClassProgressionEntry,
+  Race,
+  SubclassFeature,
+} from '../types'
 import { Panel } from './Panel'
 
 interface BuildLibraryProps {
@@ -20,6 +27,89 @@ const emptyLevel: BuildLevel = {
   subclass_choice: '',
   multiclass_choice: '',
   note: '',
+}
+
+function splitFeatureList(raw?: string | null): string[] {
+  if (!raw) {
+    return []
+  }
+  return raw
+    .split(/[,•/\n;]/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && entry !== '-')
+}
+
+function normalize(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function extractSelectedOptions(source: string | null | undefined, options: string[]): string[] {
+  if (!source) {
+    return []
+  }
+  const normalizedOptions = new Map(options.map((option) => [normalize(option), option]))
+  return source
+    .split(/[,•/\n;]/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => normalizedOptions.get(normalize(entry)) ?? null)
+    .filter((entry): entry is string => entry != null)
+}
+
+const progressionFieldLabels: Array<{
+  key: keyof ClassProgressionEntry
+  label: string
+  formatter?: (value: NonNullable<ClassProgressionEntry[keyof ClassProgressionEntry]>) => string
+}> = [
+  { key: 'proficiency_bonus', label: 'Bonus de maîtrise' },
+  { key: 'rage_charges', label: 'Charges de rage' },
+  { key: 'rage_damage', label: 'Bonus de dégâts (Rage)' },
+  { key: 'cantrips_known', label: 'Tours de magie connus' },
+  { key: 'spells_known', label: 'Sorts connus' },
+  { key: 'spell_slots_1st', label: 'Emplacements de sorts (niv. 1)' },
+  { key: 'spell_slots_2nd', label: 'Emplacements de sorts (niv. 2)' },
+  { key: 'spell_slots_3rd', label: 'Emplacements de sorts (niv. 3)' },
+  { key: 'spell_slots_4th', label: 'Emplacements de sorts (niv. 4)' },
+  { key: 'spell_slots_5th', label: 'Emplacements de sorts (niv. 5)' },
+  { key: 'spell_slots_6th', label: 'Emplacements de sorts (niv. 6)' },
+  { key: 'sorcery_points', label: 'Points de sorcellerie' },
+  { key: 'sneak_attack_damage', label: 'Attaque sournoise' },
+  { key: 'bardic_inspiration_charges', label: 'Charges Inspiration bardique' },
+  { key: 'channel_divinity_charges', label: 'Charges Canalisation divine' },
+  { key: 'lay_on_hands_charges', label: 'Réserves d’imposition des mains' },
+  { key: 'ki_points', label: 'Points de ki' },
+  { key: 'unarmoured_movement_bonus', label: 'Bonus de déplacement (sans armure)' },
+  { key: 'martial_arts_damage', label: 'Dégâts d’arts martiaux' },
+  { key: 'spell_slots_per_level', label: 'Emplacements par niveau' },
+  { key: 'invocations_known', label: 'Invocations connues' },
+]
+
+function getProgressionHighlights(entry?: ClassProgressionEntry): Array<{ label: string; value: string }> {
+  if (!entry) return []
+  return progressionFieldLabels
+    .map(({ key, label, formatter }) => {
+      const value = entry[key]
+      if (value == null) {
+        return null
+      }
+      if (typeof value === 'number') {
+        if (!Number.isFinite(value) || value <= 0) {
+          return null
+        }
+        return { label, value: `${value}` }
+      }
+      const trimmed = `${value}`.trim()
+      if (!trimmed || trimmed === '-' || trimmed.toLowerCase() === 'none') {
+        return null
+      }
+      return { label, value: formatter ? formatter(value) : trimmed }
+    })
+    .filter((entry): entry is { label: string; value: string } => entry != null)
+}
+
+function renderFeatureDescription(feature: SubclassFeature) {
+  const description = feature.feature_description?.trim()
+  return description ? description : null
 }
 
 export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDelete }: BuildLibraryProps) {
@@ -65,10 +155,55 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
 
   const classOptions = useMemo(() => classes.map((klass) => klass.name), [classes])
 
+  const selectedClass = useMemo(
+    () => classes.find((klass) => klass.name === form.class_name) ?? null,
+    [classes, form.class_name],
+  )
+
   const subclassOptions = useMemo(() => {
-    if (!form.class_name) return []
-    return classes.find((klass) => klass.name === form.class_name)?.subclasses.map((entry) => entry.name) ?? []
-  }, [classes, form.class_name])
+    if (!selectedClass) return []
+    return selectedClass.subclasses.map((entry) => entry.name)
+  }, [selectedClass])
+
+  const selectedSubclass = useMemo(
+    () => selectedClass?.subclasses.find((entry) => entry.name === form.subclass) ?? null,
+    [selectedClass, form.subclass],
+  )
+
+  const classHighlights = useMemo(() => {
+    if (!selectedClass) return []
+    const entries: Array<{ label: string; value: string | null | undefined }> = [
+      { label: 'Points de vie (niveau 1)', value: selectedClass.hit_points_at_level1 },
+      { label: 'Points de vie par niveau', value: selectedClass.hit_points_on_level_up },
+      { label: 'Caractéristiques clés', value: selectedClass.key_abilities },
+      { label: 'Jets de sauvegarde', value: selectedClass.saving_throw_proficiencies },
+      { label: 'Maîtrises d’équipement', value: selectedClass.equipment_proficiencies },
+      { label: 'Compétences', value: selectedClass.skill_proficiencies },
+      { label: "Caractéristique d'incantation", value: selectedClass.spellcasting_ability },
+      { label: 'Équipement de départ', value: selectedClass.starting_equipment },
+    ]
+    return entries
+      .map(({ label, value }) => {
+        const content = value?.trim()
+        if (!content) {
+          return null
+        }
+        return { label, value: content }
+      })
+      .filter((entry): entry is { label: string; value: string } => entry != null)
+  }, [selectedClass])
+
+  const subclassFeaturesByLevel = useMemo(() => {
+    if (!selectedSubclass) return new Map<number, SubclassFeature[]>()
+    const grouped = new Map<number, SubclassFeature[]>()
+    for (const feature of selectedSubclass.features) {
+      if (!grouped.has(feature.level)) {
+        grouped.set(feature.level, [])
+      }
+      grouped.get(feature.level)?.push(feature)
+    }
+    return grouped
+  }, [selectedSubclass])
 
   async function handleSubmit() {
     const payload: Omit<Build, 'id'> = {
@@ -274,6 +409,36 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
                   </select>
                 </label>
               </div>
+              {selectedClass ? (
+                <section className="build-form__class-overview">
+                  <header className="build-form__class-overview-header">
+                    <div>
+                      <h4>{selectedClass.name}</h4>
+                      {selectedClass.description ? (
+                        <p className="build-form__class-description">{selectedClass.description}</p>
+                      ) : null}
+                    </div>
+                  </header>
+                  {classHighlights.length ? (
+                    <dl className="build-form__class-details">
+                      {classHighlights.map((entry) => (
+                        <div key={entry.label}>
+                          <dt>{entry.label}</dt>
+                          <dd>{entry.value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                  ) : null}
+                </section>
+              ) : null}
+              {selectedSubclass ? (
+                <section className="build-form__subclass-overview">
+                  <h5>{selectedSubclass.name}</h5>
+                  {selectedSubclass.description ? (
+                    <p className="build-form__class-description">{selectedSubclass.description}</p>
+                  ) : null}
+                </section>
+              ) : null}
               <label>
                 Notes générales
                 <textarea
@@ -289,65 +454,171 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
                     Ajouter un niveau
                   </button>
                 </div>
-                {form.levels.map((level, index) => (
-                  <div key={`${level.level}-${index}`} className="build-form__level">
-                    <label>
-                      Niveau
-                      <select
-                        value={level.level}
-                        onChange={(event) =>
-                          updateLevel(index, { level: Number.parseInt(event.target.value, 10) })
-                        }
-                      >
-                        {abilityLevels.map((value) => (
-                          <option key={value} value={value}>
-                            {value}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                    <label>
-                      Sorts / dons de classe
-                      <textarea
-                        rows={2}
-                        value={level.spells ?? ''}
-                        onChange={(event) => updateLevel(index, { spells: event.target.value })}
-                      />
-                    </label>
-                    <label>
-                      Dons
-                      <textarea
-                        rows={2}
-                        value={level.feats ?? ''}
-                        onChange={(event) => updateLevel(index, { feats: event.target.value })}
-                      />
-                    </label>
-                    <label>
-                      Spécialisation / multi-classe
-                      <textarea
-                        rows={2}
-                        value={level.subclass_choice ?? level.multiclass_choice ?? ''}
-                        onChange={(event) =>
-                          updateLevel(index, {
-                            subclass_choice: event.target.value,
-                            multiclass_choice: event.target.value,
-                          })
-                        }
-                      />
-                    </label>
-                    <label>
-                      Note
-                      <textarea
-                        rows={2}
-                        value={level.note ?? ''}
-                        onChange={(event) => updateLevel(index, { note: event.target.value })}
-                      />
-                    </label>
-                    <button type="button" className="link link--danger" onClick={() => removeLevel(index)}>
-                      Retirer ce palier
-                    </button>
-                  </div>
-                ))}
+                {form.levels.map((level, index) => {
+                  const classProgression = selectedClass?.progression.find((entry) => entry.level === level.level)
+                  const classFeatureOptions = splitFeatureList(classProgression?.features)
+                  const selectedClassFeatures = extractSelectedOptions(level.spells ?? '', classFeatureOptions)
+                  const progressionHighlights = getProgressionHighlights(classProgression)
+                  const subclassFeatures = subclassFeaturesByLevel.get(level.level) ?? []
+                  const subclassFeatureOptions = subclassFeatures.map((feature) => feature.feature_name)
+                  const selectedSubclassFeatures = extractSelectedOptions(level.subclass_choice ?? '', subclassFeatureOptions)
+
+                  return (
+                    <div key={`${level.level}-${index}`} className="build-form__level">
+                      <div className="build-form__level-header">
+                        <label className="build-form__level-select">
+                          Niveau
+                          <select
+                            value={level.level}
+                            onChange={(event) =>
+                              updateLevel(index, { level: Number.parseInt(event.target.value, 10) })
+                            }
+                          >
+                            {abilityLevels.map((value) => (
+                              <option key={value} value={value}>
+                                {value}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                        {progressionHighlights.length ? (
+                          <dl className="build-form__level-stats">
+                            {progressionHighlights.map((entry) => (
+                              <div key={entry.label}>
+                                <dt>{entry.label}</dt>
+                                <dd>{entry.value}</dd>
+                              </div>
+                            ))}
+                          </dl>
+                        ) : selectedClass ? (
+                          <p className="build-form__hint build-form__hint--muted">
+                            Aucun changement majeur pour ce niveau.
+                          </p>
+                        ) : (
+                          <p className="build-form__hint build-form__hint--muted">
+                            Choisissez une classe pour afficher sa progression détaillée.
+                          </p>
+                        )}
+                      </div>
+
+                      {classFeatureOptions.length ? (
+                        <div className="build-form__level-section">
+                          <label>
+                            Capacités de classe disponibles
+                            <select
+                              multiple
+                              value={selectedClassFeatures}
+                              onChange={(event) => {
+                                const values = Array.from(event.target.selectedOptions, (option) => option.value)
+                                updateLevel(index, { spells: values.join('\n') })
+                              }}
+                            >
+                              {classFeatureOptions.map((feature) => (
+                                <option key={feature} value={feature}>
+                                  {feature}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                          <p className="build-form__hint">
+                            Maintenez Ctrl (ou Cmd) pour sélectionner plusieurs capacités à mettre en avant.
+                          </p>
+                        </div>
+                      ) : (
+                        <p className="build-form__hint build-form__hint--muted">
+                          Ce niveau n’accorde pas de nouvelle capacité de classe.
+                        </p>
+                      )}
+
+                      <label className="build-form__level-summary">
+                        Résumé de vos choix de classe
+                        <textarea
+                          rows={2}
+                          value={level.spells ?? ''}
+                          onChange={(event) => updateLevel(index, { spells: event.target.value })}
+                          placeholder="Décrivez les capacités ou combinaisons que vous souhaitez retenir pour ce niveau."
+                        />
+                      </label>
+
+                      {subclassFeatures.length ? (
+                        <div className="build-form__level-section">
+                          <label>
+                            Capacités de sous-classe
+                            <select
+                              multiple
+                              value={selectedSubclassFeatures}
+                              onChange={(event) => {
+                                const values = Array.from(event.target.selectedOptions, (option) => option.value)
+                                updateLevel(index, { subclass_choice: values.join('\n') })
+                              }}
+                            >
+                              {subclassFeatureOptions.map((feature) => (
+                                <option key={feature} value={feature}>
+                                  {feature}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                          <ul className="build-form__feature-list">
+                            {subclassFeatures.map((feature) => (
+                              <li key={`${feature.feature_name}-${feature.level}`}>
+                                <strong>{feature.feature_name}</strong>
+                                {renderFeatureDescription(feature) ? (
+                                  <p>{renderFeatureDescription(feature)}</p>
+                                ) : null}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : null}
+
+                      <div className="build-form__level-row">
+                        <label>
+                          Dons / améliorations
+                          <input
+                            type="text"
+                            value={level.feats ?? ''}
+                            onChange={(event) => updateLevel(index, { feats: event.target.value })}
+                            placeholder="Sharpshooter, Capacité améliorée…"
+                          />
+                        </label>
+                        <label>
+                          Multi-classe
+                          <select
+                            value={level.multiclass_choice ?? ''}
+                            onChange={(event) => updateLevel(index, { multiclass_choice: event.target.value })}
+                          >
+                            <option value="">—</option>
+                            {classOptions.map((className) => (
+                              <option key={className} value={className}>
+                                {className}
+                              </option>
+                            ))}
+                            {level.multiclass_choice &&
+                            level.multiclass_choice !== '' &&
+                            !classOptions.includes(level.multiclass_choice) ? (
+                              <option value={level.multiclass_choice}>{level.multiclass_choice}</option>
+                            ) : null}
+                          </select>
+                        </label>
+                      </div>
+
+                      <label>
+                        Notes détaillées
+                        <textarea
+                          rows={3}
+                          value={level.note ?? ''}
+                          onChange={(event) => updateLevel(index, { note: event.target.value })}
+                          placeholder="Ajoutez des précisions sur ce palier, des choix personnels ou des variantes."
+                        />
+                      </label>
+
+                      <button type="button" className="link link--danger" onClick={() => removeLevel(index)}>
+                        Retirer ce palier
+                      </button>
+                    </div>
+                  )
+                })}
               </div>
               <button type="submit">{isEditing ? 'Mettre à jour le build' : 'Enregistrer le build'}</button>
             </form>


### PR DESCRIPTION
## Summary
- replace the free-form build editor with a class-aware workflow that surfaces BG3 class and subclass data
- show class descriptions, core attributes, and level progression metrics directly from bg3_classes.db
- add multi-select helpers for class/subclass features plus structured multi-class and feat fields with refreshed styling

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb401e9074832bb6b882b429d2de5f