### PR TITLE
Mette à jour la table de progression des fiches

### DIFF
--- a/frontend/src/components/BuildLibrary.tsx
+++ b/frontend/src/components/BuildLibrary.tsx
@@ -1,12 +1,6 @@
 import { useMemo, useState } from 'react'
-import type {
-  Build,
-  BuildLevel,
-  CharacterClass,
-  ClassProgressionEntry,
-  Race,
-  SubclassFeature,
-} from '../types'
+import type { Build, BuildLevel, CharacterClass, Race, SubclassFeature } from '../types'
+import { getProgressionHighlights } from '../utils/progression'
 import { Panel } from './Panel'
 
 interface BuildLibraryProps {
@@ -54,57 +48,6 @@ function extractSelectedOptions(source: string | null | undefined, options: stri
     .filter((entry) => entry.length > 0)
     .map((entry) => normalizedOptions.get(normalize(entry)) ?? null)
     .filter((entry): entry is string => entry != null)
-}
-
-const progressionFieldLabels: Array<{
-  key: keyof ClassProgressionEntry
-  label: string
-  formatter?: (value: NonNullable<ClassProgressionEntry[keyof ClassProgressionEntry]>) => string
-}> = [
-  { key: 'proficiency_bonus', label: 'Bonus de maîtrise' },
-  { key: 'rage_charges', label: 'Charges de rage' },
-  { key: 'rage_damage', label: 'Bonus de dégâts (Rage)' },
-  { key: 'cantrips_known', label: 'Tours de magie connus' },
-  { key: 'spells_known', label: 'Sorts connus' },
-  { key: 'spell_slots_1st', label: 'Emplacements de sorts (niv. 1)' },
-  { key: 'spell_slots_2nd', label: 'Emplacements de sorts (niv. 2)' },
-  { key: 'spell_slots_3rd', label: 'Emplacements de sorts (niv. 3)' },
-  { key: 'spell_slots_4th', label: 'Emplacements de sorts (niv. 4)' },
-  { key: 'spell_slots_5th', label: 'Emplacements de sorts (niv. 5)' },
-  { key: 'spell_slots_6th', label: 'Emplacements de sorts (niv. 6)' },
-  { key: 'sorcery_points', label: 'Points de sorcellerie' },
-  { key: 'sneak_attack_damage', label: 'Attaque sournoise' },
-  { key: 'bardic_inspiration_charges', label: 'Charges Inspiration bardique' },
-  { key: 'channel_divinity_charges', label: 'Charges Canalisation divine' },
-  { key: 'lay_on_hands_charges', label: 'Réserves d’imposition des mains' },
-  { key: 'ki_points', label: 'Points de ki' },
-  { key: 'unarmoured_movement_bonus', label: 'Bonus de déplacement (sans armure)' },
-  { key: 'martial_arts_damage', label: 'Dégâts d’arts martiaux' },
-  { key: 'spell_slots_per_level', label: 'Emplacements par niveau' },
-  { key: 'invocations_known', label: 'Invocations connues' },
-]
-
-function getProgressionHighlights(entry?: ClassProgressionEntry): Array<{ label: string; value: string }> {
-  if (!entry) return []
-  return progressionFieldLabels
-    .map(({ key, label, formatter }) => {
-      const value = entry[key]
-      if (value == null) {
-        return null
-      }
-      if (typeof value === 'number') {
-        if (!Number.isFinite(value) || value <= 0) {
-          return null
-        }
-        return { label, value: `${value}` }
-      }
-      const trimmed = `${value}`.trim()
-      if (!trimmed || trimmed === '-' || trimmed.toLowerCase() === 'none') {
-        return null
-      }
-      return { label, value: formatter ? formatter(value) : trimmed }
-    })
-    .filter((entry): entry is { label: string; value: string } => entry != null)
 }
 
 function renderFeatureDescription(feature: SubclassFeature) {

--- a/frontend/src/components/CharacterSheet.tsx
+++ b/frontend/src/components/CharacterSheet.tsx
@@ -17,6 +17,7 @@ import type {
 } from '../types'
 import { equipmentSlotLabels, equipmentSlotOrder } from '../utils/equipment'
 import { getIconUrl, normalizeName, type IconCategory } from '../utils/icons'
+import { getProgressionHighlights } from '../utils/progression'
 import { getSpellLevelLabel, sortSpellsByLevel } from '../utils/spells'
 import { IconCard } from './IconCard'
 import { Panel } from './Panel'
@@ -605,24 +606,32 @@ export function CharacterSheet({
         <section className="character-sheet__progression">
           <h4>Table de progression : {classInfo.name}</h4>
           <div className="progression-table">
-            {classInfo.progression.map((entry) => (
-              <div key={entry.level} className={entry.level === nextLevel ? 'progression-table__row progression-table__row--active' : 'progression-table__row'}>
-                <div>
-                  <strong>Niveau {entry.level}</strong>
-                </div>
-                <div>
-                  <strong>Bonus de maîtrise :</strong> {entry.proficiency_bonus || '—'}
-                </div>
-                <div>
-                  <strong>Traits :</strong> {entry.features || '—'}
-                </div>
-                {entry.spell_slots_1st ? (
+            {classInfo.progression.map((entry) => {
+              const progressionHighlights = getProgressionHighlights(entry)
+
+              return (
+                <div
+                  key={entry.level}
+                  className={
+                    entry.level === nextLevel
+                      ? 'progression-table__row progression-table__row--active'
+                      : 'progression-table__row'
+                  }
+                >
                   <div>
-                    <strong>Emplacements :</strong> {entry.spell_slots_per_level || '1er:' + entry.spell_slots_1st}
+                    <strong>Niveau {entry.level}</strong>
                   </div>
-                ) : null}
-              </div>
-            ))}
+                  <div>
+                    <strong>Traits :</strong> {entry.features || '—'}
+                  </div>
+                  {progressionHighlights.map((highlight) => (
+                    <div key={highlight.label}>
+                      <strong>{highlight.label} :</strong> {highlight.value}
+                    </div>
+                  ))}
+                </div>
+              )
+            })}
           </div>
         </section>
       ) : null}

--- a/frontend/src/utils/progression.ts
+++ b/frontend/src/utils/progression.ts
@@ -1,0 +1,53 @@
+import type { ClassProgressionEntry } from '../types'
+
+export const progressionFieldLabels: Array<{
+  key: keyof ClassProgressionEntry
+  label: string
+  formatter?: (value: NonNullable<ClassProgressionEntry[keyof ClassProgressionEntry]>) => string
+}> = [
+  { key: 'proficiency_bonus', label: 'Bonus de maîtrise' },
+  { key: 'rage_charges', label: 'Charges de rage' },
+  { key: 'rage_damage', label: 'Bonus de dégâts (Rage)' },
+  { key: 'cantrips_known', label: 'Tours de magie connus' },
+  { key: 'spells_known', label: 'Sorts connus' },
+  { key: 'spell_slots_1st', label: 'Emplacements de sorts (niv. 1)' },
+  { key: 'spell_slots_2nd', label: 'Emplacements de sorts (niv. 2)' },
+  { key: 'spell_slots_3rd', label: 'Emplacements de sorts (niv. 3)' },
+  { key: 'spell_slots_4th', label: 'Emplacements de sorts (niv. 4)' },
+  { key: 'spell_slots_5th', label: 'Emplacements de sorts (niv. 5)' },
+  { key: 'spell_slots_6th', label: 'Emplacements de sorts (niv. 6)' },
+  { key: 'sorcery_points', label: 'Points de sorcellerie' },
+  { key: 'sneak_attack_damage', label: 'Attaque sournoise' },
+  { key: 'bardic_inspiration_charges', label: 'Charges Inspiration bardique' },
+  { key: 'channel_divinity_charges', label: 'Charges Canalisation divine' },
+  { key: 'lay_on_hands_charges', label: 'Réserves d’imposition des mains' },
+  { key: 'ki_points', label: 'Points de ki' },
+  { key: 'unarmoured_movement_bonus', label: 'Bonus de déplacement (sans armure)' },
+  { key: 'martial_arts_damage', label: 'Dégâts d’arts martiaux' },
+  { key: 'spell_slots_per_level', label: 'Emplacements par niveau' },
+  { key: 'invocations_known', label: 'Invocations connues' },
+]
+
+export function getProgressionHighlights(entry?: ClassProgressionEntry): Array<{ label: string; value: string }> {
+  if (!entry) return []
+
+  return progressionFieldLabels
+    .map(({ key, label, formatter }) => {
+      const value = entry[key]
+      if (value == null) {
+        return null
+      }
+      if (typeof value === 'number') {
+        if (!Number.isFinite(value) || value <= 0) {
+          return null
+        }
+        return { label, value: `${value}` }
+      }
+      const trimmed = `${value}`.trim()
+      if (!trimmed || trimmed === '-' || trimmed.toLowerCase() === 'none') {
+        return null
+      }
+      return { label, value: formatter ? formatter(value) : trimmed }
+    })
+    .filter((entry): entry is { label: string; value: string } => entry != null)
+}


### PR DESCRIPTION
## Summary
- extrait la configuration des champs de progression dans un utilitaire partagé
- réutilise ces informations pour enrichir la table de progression de la fiche personnage
- aligne la bibliothèque de builds sur le même utilitaire

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb446e6128832b8caa84590a76bf5a