### PR TITLE
Improve equipment layout emphasis and tooltips

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1110,6 +1110,10 @@ button:focus-visible {
   z-index: 60;
 }
 
+.equipment-layout .icon-grid__tooltip {
+  z-index: 200;
+}
+
 .icon-grid__item:focus-visible .icon-grid__tooltip,
 .icon-grid__item:hover .icon-grid__tooltip {
   opacity: 1;
@@ -1251,6 +1255,7 @@ button:focus-visible {
 
 .equipment-layout {
   position: relative;
+  z-index: 1;
   display: grid;
   gap: 0.85rem;
   grid-template-columns: repeat(3, minmax(130px, 1fr));
@@ -1279,6 +1284,7 @@ button:focus-visible {
   border-radius: inherit;
   border: 1px solid rgba(255, 255, 255, 0.03);
   pointer-events: none;
+  z-index: -1;
 }
 
 .equipment-layout__character {
@@ -1300,8 +1306,8 @@ button:focus-visible {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.55rem 0.65rem;
+  gap: 0.3rem;
+  padding: 0.75rem 0.75rem 0.6rem;
   border-radius: 16px;
   background: rgba(16, 28, 52, 0.68);
   border: 1px solid rgba(148, 163, 184, 0.18);
@@ -1314,32 +1320,39 @@ button:focus-visible {
 }
 
 .equipment-slot__label {
-  font-size: 0.78rem;
+  align-self: flex-start;
+  font-size: 0.62rem;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.18em;
   color: var(--color-text-muted);
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+  line-height: 1;
 }
 
 .equipment-slot__card {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.45rem;
+  justify-items: center;
   color: var(--color-text-secondary);
 }
 
 .equipment-slot .icon-grid__item {
-  gap: 0.3rem;
-  padding: 0.45rem 0.4rem;
-  border-radius: 12px;
+  gap: 0.35rem;
+  padding: 0.6rem 0.55rem;
+  border-radius: 16px;
 }
 
 .equipment-slot .icon-grid__image {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
+  width: 60px;
+  height: 60px;
+  border-radius: 14px;
 }
 
 .equipment-slot .icon-grid__label {
-  font-size: 0.85rem;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
 }
 
 .equipment-slot__value {


### PR DESCRIPTION
## Summary
- raise the equipment layout stacking order so item tooltips are no longer hidden behind surrounding panels
- restyle equipment slot labels as subtle badges so the visuals emphasize the item art
- enlarge equipment icons and adjust card spacing for a more readable, image-centric layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc2a63946c832b83148498c81c3011