### PR TITLE
Adjust equipment layout tooltip opacity

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1112,6 +1112,7 @@ button:focus-visible {
 
 .equipment-layout .icon-grid__tooltip {
   z-index: 200;
+  background: rgba(9, 18, 32, 0.8);
 }
 
 .icon-grid__item:focus-visible .icon-grid__tooltip,


### PR DESCRIPTION
## Summary
- increase the tooltip background opacity within the equipment layout to improve readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc2c43c164832bb085675722f27f00