### PR TITLE
Enhance tooltip contrast

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1099,15 +1099,16 @@ button:focus-visible {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease;
-  background: rgba(9, 18, 32, 0.95);
-  border-radius: 16px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(155deg, rgba(17, 30, 54, 0.96), rgba(11, 23, 42, 0.92));
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
   min-width: 240px;
   max-width: 320px;
-  box-shadow: 0 24px 40px rgba(4, 10, 30, 0.55);
-  padding: 1rem 1.2rem;
+  box-shadow: 0 30px 55px rgba(4, 10, 30, 0.65), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  padding: 1.1rem 1.35rem;
   color: var(--color-text-secondary);
   z-index: 60;
+  backdrop-filter: blur(calc(var(--blur-strength) * 0.75));
 }
 
 .equipment-layout .icon-grid__tooltip {


### PR DESCRIPTION
## Summary
- restyle the tooltip background with a richer gradient, stronger border, and inset highlight to separate it from overlapping cards
- adjust padding, border radius, shadow, and add a subtle blur so hover tooltips remain readable against the interface

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc2ddcd5c4832ba2937a2067f327ae