### PR TITLE
Align tooltip styling with grimoire appearance

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1250,6 +1250,15 @@ button:focus-visible {
   gap: 0.55rem;
 }
 
+.icon-grid__tooltip-title {
+  margin: 0;
+  font-family: 'Cinzel', serif;
+  font-size: 0.92rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-primary);
+}
+
 .icon-grid__tooltip-meta {
   display: grid;
   gap: 0.3rem;

--- a/frontend/src/components/IconCard.tsx
+++ b/frontend/src/components/IconCard.tsx
@@ -30,12 +30,15 @@ export function IconCard({ name, iconUrl, children }: IconCardProps) {
           </span>
         )}
       </div>
-      <span className="icon-grid__label" title={name}>
+      <span className="icon-grid__label">
         <span className="icon-grid__label-text">{name}</span>
       </span>
       {hasTooltip ? (
         <div className="icon-grid__tooltip" id={tooltipId} role="tooltip">
-          <div className="icon-grid__tooltip-content">{children}</div>
+          <div className="icon-grid__tooltip-content">
+            <p className="icon-grid__tooltip-title">{name}</p>
+            {children}
+          </div>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- add a shared title element inside icon card tooltips so every tooltip shows the item name with the grimoire styling
- remove the native title attribute and introduce a reusable tooltip heading style in App.css

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdc4e89aa4832b8ab01ad5b18d0f7a