### PR TITLE
Allow build editor to plan class spells

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -316,6 +316,12 @@ class CharacterClass(BaseModel):
     starting_equipment: Optional[str] = None
     subclasses: List[Subclass] = Field(default_factory=list)
     progression: List[ClassProgressionEntry] = Field(default_factory=list)
+    spells_learned: List["ClassSpellList"] = Field(default_factory=list)
+
+
+class ClassSpellList(BaseModel):
+    level: int = Field(ge=1, le=12)
+    spells: List[str] = Field(default_factory=list)
 
 
 class BackgroundSkill(BaseModel):

--- a/backend/tests/test_classes.py
+++ b/backend/tests/test_classes.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+
+
+def test_classes_expose_spells_learned(client: TestClient) -> None:
+    response = client.get('/api/classes')
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert isinstance(payload, list)
+
+    wizard = next((entry for entry in payload if entry['name'] == 'Wizard'), None)
+    assert wizard is not None
+
+    spells_learned = wizard['spells_learned']
+    assert isinstance(spells_learned, list)
+    assert spells_learned, 'expected wizard to learn spells at some levels'
+
+    levels = [entry['level'] for entry in spells_learned]
+    assert levels == sorted(levels)
+
+    for entry in spells_learned:
+        assert 'level' in entry and 'spells' in entry
+        assert entry['spells'] == sorted(entry['spells'])

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -639,6 +639,56 @@ button:focus-visible {
   gap: 0.4rem;
 }
 
+.build-form__level-section--spells {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: rgba(8, 16, 32, 0.4);
+  gap: 0.6rem;
+}
+
+.build-form__spell-options {
+  display: grid;
+  gap: 0.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.build-form__spell-option {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.build-form__spell-option input {
+  width: auto;
+}
+
+.build-form__spell-replacements {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.build-form__spell-replacement-row {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, auto));
+  align-items: center;
+}
+
+.build-form__spell-replacement-row span {
+  text-align: center;
+  font-size: 1.1rem;
+}
+
+.build-form__spell-replacement-row button {
+  justify-self: start;
+}
+
+.build-form__spell-replacements button {
+  justify-self: start;
+}
+
 .build-form__level-summary {
   display: grid;
   gap: 0.4rem;

--- a/frontend/src/components/BuildLibrary.tsx
+++ b/frontend/src/components/BuildLibrary.tsx
@@ -23,7 +23,7 @@ const abilityLevels = Array.from({ length: 12 }, (_, index) => index + 1)
 
 type BuildFormLevel = BuildLevel & { spellPlan: BuildSpellPlan }
 
-type BuildFormState = Omit<Build, 'id'> & { levels: BuildFormLevel[] }
+type BuildFormState = Omit<Build, 'id' | 'levels'> & { levels: BuildFormLevel[] }
 
 function splitFeatureList(raw?: string | null): string[] {
   if (!raw) {
@@ -252,7 +252,7 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
 
   function updateLevel(index: number, updates: Partial<BuildFormLevel>) {
     setForm((state) => {
-      const nextLevels = state.levels.map((level, i) => {
+      const nextLevels: BuildFormLevel[] = state.levels.map((level, i): BuildFormLevel => {
         if (i !== index) {
           return level
         }
@@ -270,7 +270,7 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
 
   function updateSpellPlan(index: number, updater: (plan: BuildSpellPlan) => BuildSpellPlan) {
     setForm((state) => {
-      const nextLevels = state.levels.map((level, i) =>
+      const nextLevels: BuildFormLevel[] = state.levels.map((level, i): BuildFormLevel =>
         i === index
           ? {
               ...level,
@@ -325,17 +325,20 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
   }
 
   function addLevel() {
-    setForm((state) => ({
-      ...state,
-      levels: [...state.levels, createEmptyLevel(Math.min(12, state.levels.length + 1))],
-    }))
+    setForm((state) => {
+      const nextLevels: BuildFormLevel[] = [
+        ...state.levels,
+        createEmptyLevel(Math.min(12, state.levels.length + 1)),
+      ]
+      return { ...state, levels: nextLevels }
+    })
   }
 
   function removeLevel(index: number) {
-    setForm((state) => ({
-      ...state,
-      levels: state.levels.filter((_, i) => i !== index),
-    }))
+    setForm((state) => {
+      const nextLevels: BuildFormLevel[] = state.levels.filter((_, i) => i !== index)
+      return { ...state, levels: nextLevels }
+    })
   }
 
   function handleCreateClick() {
@@ -443,7 +446,7 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
                     onChange={(event) => {
                       const nextClass = event.target.value
                       setForm((state) => {
-                        const nextLevels = state.levels.map((level) => {
+                        const nextLevels: BuildFormLevel[] = state.levels.map((level): BuildFormLevel => {
                           if (level.multiclass_choice) {
                             return level
                           }
@@ -658,7 +661,7 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
                           {knownSpellsBefore.length || plan.replacements.length ? (
                             <div className="build-form__spell-replacements">
                               <h6>Remplacements possibles</h6>
-                              {plan.replacements.map((replacement, replacementIndex) => (
+                              {plan.replacements.map((replacement: BuildSpellReplacement, replacementIndex) => (
                                 <div
                                   key={`replacement-${replacementIndex}`}
                                   className="build-form__spell-replacement-row"

--- a/frontend/src/components/CharacterSheet.tsx
+++ b/frontend/src/components/CharacterSheet.tsx
@@ -18,7 +18,7 @@ import type {
 import { equipmentSlotLabels, equipmentSlotOrder } from '../utils/equipment'
 import { getIconUrl, normalizeName, type IconCategory } from '../utils/icons'
 import { getProgressionHighlights } from '../utils/progression'
-import { getSpellLevelLabel, sortSpellsByLevel } from '../utils/spells'
+import { describeBuildSpellPlan, getSpellLevelLabel, parseBuildSpellPlan, sortSpellsByLevel } from '../utils/spells'
 import { IconCard } from './IconCard'
 import { Panel } from './Panel'
 
@@ -427,6 +427,20 @@ export function CharacterSheet({
     [spells, member],
   )
 
+  const nextLevelTarget = member ? Math.min(12, member.level + 1) : null
+  const nextStep = useMemo(
+    () =>
+      build && nextLevelTarget != null
+        ? build.levels.find((level) => level.level === nextLevelTarget) ?? null
+        : null,
+    [build, nextLevelTarget],
+  )
+  const nextStepSpellPlan = useMemo(
+    () => (nextStep ? parseBuildSpellPlan(nextStep.spells ?? '') : null),
+    [nextStep],
+  )
+  const nextStepSpellSummary = nextStepSpellPlan ? describeBuildSpellPlan(nextStepSpellPlan) : ''
+
   if (!member) {
     return (
       <Panel title="Fiche de personnage" subtitle="Sélectionnez un héros pour consulter ses détails">
@@ -436,7 +450,6 @@ export function CharacterSheet({
   }
   const gear = member.equipment ?? {}
   const nextLevel = Math.min(12, member.level + 1)
-  const nextStep = build?.levels.find((level) => level.level === nextLevel)
 
   return (
     <Panel
@@ -493,7 +506,7 @@ export function CharacterSheet({
                 <div className="character-sheet__next-step">
                   <h5>Préparez le niveau {nextLevel}</h5>
                   <p>
-                    <strong>Sorts :</strong> {nextStep.spells || '—'}
+                    <strong>Sorts :</strong> {nextStepSpellSummary || '—'}
                   </p>
                   <p>
                     <strong>Dons :</strong> {nextStep.feats || '—'}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -231,6 +231,11 @@ export interface ClassProgressionEntry {
   invocations_known?: number | null
 }
 
+export interface ClassSpellList {
+  level: number
+  spells: string[]
+}
+
 export interface CharacterClass {
   name: string
   description?: string | null
@@ -244,6 +249,7 @@ export interface CharacterClass {
   starting_equipment?: string | null
   subclasses: Subclass[]
   progression: ClassProgressionEntry[]
+  spells_learned: ClassSpellList[]
 }
 
 export interface Background {

--- a/frontend/src/utils/spells.ts
+++ b/frontend/src/utils/spells.ts
@@ -57,3 +57,112 @@ export function sortSpellsByLevel(spellA: Spell, spellB: Spell): number {
   const levelB = Number.parseInt(getNormalizedSpellLevel(spellB.level) ?? '99', 10)
   return levelA - levelB || spellA.name.localeCompare(spellB.name, 'fr')
 }
+
+export interface BuildSpellReplacement {
+  previous: string
+  next: string
+}
+
+export interface BuildSpellPlan {
+  summary: string
+  learned: string[]
+  replacements: BuildSpellReplacement[]
+}
+
+function sanitizeSpellList(values: string[] | undefined): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of values ?? []) {
+    if (!value || typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+  return result
+}
+
+function sanitizeReplacements(values: BuildSpellReplacement[] | undefined): BuildSpellReplacement[] {
+  const result: BuildSpellReplacement[] = []
+  for (const entry of values ?? []) {
+    if (!entry || typeof entry !== 'object') continue
+    const previous = typeof entry.previous === 'string' ? entry.previous.trim() : ''
+    const next = typeof entry.next === 'string' ? entry.next.trim() : ''
+    if (!previous && !next) {
+      continue
+    }
+    result.push({ previous, next })
+  }
+  return result
+}
+
+export function createEmptyBuildSpellPlan(summary = ''): BuildSpellPlan {
+  return {
+    summary,
+    learned: [],
+    replacements: [],
+  }
+}
+
+export function parseBuildSpellPlan(raw: string | null | undefined): BuildSpellPlan {
+  if (!raw) {
+    return createEmptyBuildSpellPlan()
+  }
+  const trimmed = raw.trim()
+  if (!trimmed) {
+    return createEmptyBuildSpellPlan()
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return createEmptyBuildSpellPlan(trimmed)
+    }
+    const summary = typeof (parsed as { summary?: unknown }).summary === 'string' ? (parsed as { summary: string }).summary : ''
+    const learned = sanitizeSpellList((parsed as { learned?: unknown }).learned as string[] | undefined)
+    const replacements = sanitizeReplacements((parsed as { replacements?: unknown }).replacements as BuildSpellReplacement[] | undefined)
+    return {
+      summary,
+      learned,
+      replacements,
+    }
+  } catch {
+    // Legacy format stored as plain text.
+    return createEmptyBuildSpellPlan(trimmed)
+  }
+}
+
+export function serializeBuildSpellPlan(plan: BuildSpellPlan): string {
+  const summary = plan.summary.trim()
+  const learned = sanitizeSpellList(plan.learned)
+  const replacements = sanitizeReplacements(plan.replacements)
+  if (!learned.length && !replacements.length) {
+    return summary
+  }
+  return JSON.stringify({ summary, learned, replacements })
+}
+
+export function describeBuildSpellPlan(plan: BuildSpellPlan): string {
+  const summary = plan.summary.trim()
+  const learned = sanitizeSpellList(plan.learned)
+  const replacementDescriptions = sanitizeReplacements(plan.replacements).map((entry) => {
+    if (entry.previous && entry.next) {
+      return `${entry.previous} → ${entry.next}`
+    }
+    if (entry.next) {
+      return `→ ${entry.next}`
+    }
+    return `${entry.previous} remplacé`
+  })
+
+  const parts: string[] = []
+  if (learned.length) {
+    parts.push(`Nouveaux : ${learned.join(', ')}`)
+  }
+  if (replacementDescriptions.length) {
+    parts.push(`Remplacements : ${replacementDescriptions.join(', ')}`)
+  }
+  if (summary) {
+    parts.push(summary)
+  }
+  return parts.join(' • ')
+}


### PR DESCRIPTION
## Summary
- expose class spell progression through the `/api/classes` endpoint
- extend the build editor with spell planning, replacements, and supporting UI utilities
- surface the upcoming level spell plan on the character sheet and add a regression test for spell data

## Testing
- `pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cf1ff91364832b91ce246b3a8c1966