### PR TITLE
Refactor ability traits menu layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1178,14 +1178,124 @@ button:focus-visible {
   line-height: 1.4;
 }
 
-.ability-library__saves {
-  margin: 0.25rem 0 0;
-  padding-left: 1.1rem;
+.ability-library {
   display: grid;
-  gap: 0.25rem;
-  color: var(--color-text-muted);
-  font-size: 0.85rem;
+  gap: 1.35rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.ability-library__card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.2rem 1.35rem;
+  border-radius: 26px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: linear-gradient(160deg, rgba(16, 28, 52, 0.92), rgba(9, 19, 36, 0.88));
+  box-shadow: 0 18px 38px rgba(5, 12, 30, 0.36);
+}
+
+.ability-library__header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: center;
+}
+
+.ability-library__icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 22px;
+  overflow: hidden;
+  background: rgba(10, 20, 36, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: grid;
+  place-items: center;
+}
+
+.ability-library__icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ability-library__icon-placeholder {
+  font-family: 'Cinzel', serif;
+  font-size: 1.25rem;
+  letter-spacing: 0.14em;
+  color: var(--color-accent);
+}
+
+.ability-library__heading {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.ability-library__title {
+  margin: 0;
+  font-family: 'Cinzel', serif;
+  font-size: 1rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-primary);
+}
+
+.ability-library__summary {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+
+.ability-library__content {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.ability-library__section {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.9rem 1rem;
+  border-radius: 18px;
+  background: rgba(11, 22, 40, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.ability-library__section-title {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.ability-library__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.ability-library__list-item {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.ability-library__list-title {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.ability-library__list-text {
+  color: var(--color-text-secondary);
+  font-size: 0.88rem;
   line-height: 1.4;
+}
+
+.ability-library__list--saves .ability-library__list-item {
+  padding-left: 0.15rem;
 }
 
 .icon-grid {

--- a/frontend/src/components/AbilityReference.tsx
+++ b/frontend/src/components/AbilityReference.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react'
 import type { Ability } from '../types'
 import { Panel } from './Panel'
-import { IconCard } from './IconCard'
 import { getIconUrl } from '../utils/icons'
 
 interface AbilityReferenceProps {
@@ -90,73 +89,102 @@ export function AbilityReference({ abilities }: AbilityReferenceProps) {
           onChange={(event) => setSearch(event.target.value)}
         />
       </div>
-      <div className="icon-grid ability-library">
-        {filtered.map((ability) => (
-          <IconCard
-            key={ability.name}
-            name={ability.name}
-            iconUrl={getIconUrl('ability', ability.name, ability.image_path)}
-          >
-            {ability.description ? (
-              <p className="icon-grid__tooltip-description">{ability.description}</p>
-            ) : null}
-            {ability.uses.length ? (
-              <div className="icon-grid__tooltip-section">
-                <strong>Usages clés</strong>
-                <ul className="icon-grid__tooltip-list">
-                  {ability.uses.map((use) => (
-                    <li key={use.name}>
-                      <span className="icon-grid__tooltip-list-title">{formatUseName(use.name)}</span>
-                      {use.description ? <span>{use.description}</span> : null}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-            {ability.checks.length ? (
-              <div className="icon-grid__tooltip-section">
-                <strong>Tests</strong>
-                <ul className="icon-grid__tooltip-list">
-                  {ability.checks.map((check) => (
-                    <li key={check.type}>
-                      <span className="icon-grid__tooltip-list-title">{formatCheckType(check.type)}</span>
-                      {check.description ? <span>{check.description}</span> : null}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-            {ability.skills.length ? (
-              <div className="icon-grid__tooltip-section">
-                <strong>Compétences liées</strong>
-                <ul className="icon-grid__tooltip-list">
-                  {ability.skills.map((skill) => (
-                    <li key={skill.name}>
-                      <span className="icon-grid__tooltip-list-title">{skill.name}</span>
-                      {skill.description ? <span>{skill.description}</span> : null}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-            {ability.saves.length ? (
-              <div className="icon-grid__tooltip-section">
-                <strong>Jets de sauvegarde</strong>
-                <ul className="ability-library__saves">
-                  {ability.saves.map((save, index) => (
-                    <li key={`${ability.name}-save-${index}`}>
-                      {save.description ?? '—'}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-          </IconCard>
-        ))}
-        {!filtered.length ? (
-          <p className="empty">Aucune caractéristique ne correspond à votre recherche.</p>
-        ) : null}
-      </div>
+      {filtered.length ? (
+        <div className="ability-library">
+          {filtered.map((ability) => {
+            const iconUrl = getIconUrl('ability', ability.name, ability.image_path)
+
+            return (
+              <article key={ability.name} className="ability-library__card">
+                <header className="ability-library__header">
+                  <div className="ability-library__icon" aria-hidden="true">
+                    {iconUrl ? (
+                      <img src={iconUrl} alt="" loading="lazy" />
+                    ) : (
+                      <span className="ability-library__icon-placeholder">
+                        {ability.name.charAt(0)}
+                      </span>
+                    )}
+                  </div>
+                  <div className="ability-library__heading">
+                    <h3 className="ability-library__title">{ability.name}</h3>
+                    {ability.description ? (
+                      <p className="ability-library__summary">{ability.description}</p>
+                    ) : null}
+                  </div>
+                </header>
+                <div className="ability-library__content">
+                  {ability.uses.length ? (
+                    <section className="ability-library__section">
+                      <h4 className="ability-library__section-title">Usages clés</h4>
+                      <ul className="ability-library__list">
+                        {ability.uses.map((use) => (
+                          <li key={use.name} className="ability-library__list-item">
+                            <span className="ability-library__list-title">
+                              {formatUseName(use.name)}
+                            </span>
+                            {use.description ? (
+                              <span className="ability-library__list-text">{use.description}</span>
+                            ) : null}
+                          </li>
+                        ))}
+                      </ul>
+                    </section>
+                  ) : null}
+                  {ability.checks.length ? (
+                    <section className="ability-library__section">
+                      <h4 className="ability-library__section-title">Tests</h4>
+                      <ul className="ability-library__list">
+                        {ability.checks.map((check) => (
+                          <li key={check.type} className="ability-library__list-item">
+                            <span className="ability-library__list-title">
+                              {formatCheckType(check.type)}
+                            </span>
+                            {check.description ? (
+                              <span className="ability-library__list-text">{check.description}</span>
+                            ) : null}
+                          </li>
+                        ))}
+                      </ul>
+                    </section>
+                  ) : null}
+                  {ability.skills.length ? (
+                    <section className="ability-library__section">
+                      <h4 className="ability-library__section-title">Compétences liées</h4>
+                      <ul className="ability-library__list">
+                        {ability.skills.map((skill) => (
+                          <li key={skill.name} className="ability-library__list-item">
+                            <span className="ability-library__list-title">{skill.name}</span>
+                            {skill.description ? (
+                              <span className="ability-library__list-text">{skill.description}</span>
+                            ) : null}
+                          </li>
+                        ))}
+                      </ul>
+                    </section>
+                  ) : null}
+                  {ability.saves.length ? (
+                    <section className="ability-library__section">
+                      <h4 className="ability-library__section-title">Jets de sauvegarde</h4>
+                      <ul className="ability-library__list ability-library__list--saves">
+                        {ability.saves.map((save, index) => (
+                          <li key={`${ability.name}-save-${index}`} className="ability-library__list-item">
+                            <span className="ability-library__list-text">
+                              {save.description ?? '—'}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </section>
+                  ) : null}
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      ) : (
+        <p className="empty">Aucune caractéristique ne correspond à votre recherche.</p>
+      )}
     </Panel>
   )
 }


### PR DESCRIPTION
## Summary
- replace the generic icon grid in the ability traits panel with bespoke cards that surface all content without tooltips
- redesign the ability traits styling to better fill the compact menu with responsive cards and contextual sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfb6c0cb8c832b82836c18cb6d330b