### PR TITLE
Adjust ability cards to fit one row

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1009,37 +1009,38 @@ button:focus-visible {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.6rem;
-  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 0.45rem;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
 }
 
 .ability-grid li {
   background: rgba(12, 23, 42, 0.7);
-  border-radius: 16px;
-  padding: 0.65rem;
+  border-radius: 14px;
+  padding: 0.55rem;
   border: 1px solid rgba(148, 163, 184, 0.18);
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
   align-items: center;
   min-width: 0;
 }
 
 .ability-grid__label {
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--color-text-secondary);
+  font-size: 0.7rem;
 }
 
 .ability-grid__score {
-  font-size: 1.4rem;
+  font-size: 1.25rem;
   font-weight: 700;
   color: var(--color-text-primary);
 }
 
 .ability-grid__modifier {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--color-text-muted);
 }
 


### PR DESCRIPTION
## Summary
- force the characteristic grid to render six equal columns and tighten spacing
- reduce padding and font sizes on ability cards so the full set fits on one row without scrolling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfb757b7a8832b9bbd97b704718ce4