### PR TITLE
Fix character sheet equipment opacity

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1615,10 +1615,23 @@ button:focus-visible {
   border: 1px solid rgba(148, 163, 184, 0.18);
   min-height: 0;
   height: 100%;
+  z-index: 0;
 }
 
 .equipment-slot--read-only {
-  opacity: 0.65;
+  position: relative;
+  opacity: 1;
+}
+
+.equipment-slot--read-only::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(160deg, rgba(10, 20, 36, 0.35), rgba(12, 23, 42, 0.15));
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  pointer-events: none;
+  z-index: -1;
 }
 
 .equipment-slot__label {


### PR DESCRIPTION
## Summary
- remove the opacity effect on read-only equipment slots so icons, labels, and tooltips render at full brightness
- add a dedicated overlay style to keep a subtle distinction for read-only slots without affecting child content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfb9954a84832b85f5cbfdd009ffe7