### PR TITLE
Fix equipment tooltips stacking order

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1616,6 +1616,12 @@ button:focus-visible {
   min-height: 0;
   height: 100%;
   z-index: 0;
+  overflow: visible;
+}
+
+.equipment-slot:focus-within,
+.equipment-slot:hover {
+  z-index: 250;
 }
 
 .equipment-slot--read-only {


### PR DESCRIPTION
## Summary
- ensure equipment slots keep overflow visible and raise their stacking order on hover
- prevent equipment tooltips from being hidden behind neighbouring slots

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfbb7f3630832ba360ff6c74fea773