### PR TITLE
Fix panel header layout to keep toggle inside

### DIFF
--- a/frontend/src/components/panel.css
+++ b/frontend/src/components/panel.css
@@ -35,6 +35,11 @@
   border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
 
+.panel__header > div:first-child {
+  flex: 1;
+  min-width: 0;
+}
+
 .panel__header h2 {
   font-family: 'Cinzel', serif;
   font-size: 1.3rem;


### PR DESCRIPTION
## Summary
- allow the panel header title block to flex and shrink so the toggle button stays within the panel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfbcd93c4c832ba3a19a1ab2ffca75