### PR TITLE
Add level addition shortcut within level editor

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -647,6 +647,14 @@ button:focus-visible {
   gap: 0.6rem;
 }
 
+.build-form__level-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .build-form__spell-options {
   display: grid;
   gap: 0.4rem;

--- a/frontend/src/components/BuildLibrary.tsx
+++ b/frontend/src/components/BuildLibrary.tsx
@@ -907,9 +907,18 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
                         />
                       </label>
 
-                      <button type="button" className="link link--danger" onClick={() => removeLevel(index)}>
-                        Retirer ce palier
-                      </button>
+                      <div className="build-form__level-actions">
+                        <button
+                          type="button"
+                          className="link link--danger"
+                          onClick={() => removeLevel(index)}
+                        >
+                          Retirer ce palier
+                        </button>
+                        <button type="button" className="link" onClick={addLevel}>
+                          Ajouter un niveau
+                        </button>
+                      </div>
                     </div>
                   )
                 })}


### PR DESCRIPTION
## Summary
- add an "Ajouter un niveau" button at the bottom of each level block so users can add levels without scrolling
- introduce layout styling for the combined remove/add actions to keep buttons tidy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfbd34defc832b915e1db0026bcd81