### PR TITLE
Add skill selection controls to build creator

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -47,11 +47,14 @@ def _ensure_companion_schema(conn: sqlite3.Connection) -> None:
 
     cursor = conn.execute("PRAGMA table_info(build_levels)")
     columns = {row["name"] for row in cursor.fetchall()}
-    if not columns:
-        # The table does not exist in the current database; nothing to migrate.
-        return
-    if "note" not in columns:
+    if columns and "note" not in columns:
         conn.execute("ALTER TABLE build_levels ADD COLUMN note TEXT DEFAULT ''")
+        conn.commit()
+
+    cursor = conn.execute("PRAGMA table_info(builds)")
+    build_columns = {row["name"] for row in cursor.fetchall()}
+    if build_columns and "skill_choices" not in build_columns:
+        conn.execute("ALTER TABLE builds ADD COLUMN skill_choices TEXT DEFAULT '[]'")
         conn.commit()
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -56,6 +56,7 @@ class BuildBase(BaseModel):
     class_name: Optional[str] = Field(default=None, alias="class")
     subclass: Optional[str] = None
     notes: Optional[str] = None
+    skill_choices: List[str] = Field(default_factory=list)
     levels: List[BuildLevel] = Field(default_factory=list)
 
     model_config = {"populate_by_name": True}

--- a/backend/tests/test_builds.py
+++ b/backend/tests/test_builds.py
@@ -21,7 +21,8 @@ def _prepare_build_tables(db_path: Path) -> None:
                 race TEXT,
                 class TEXT,
                 subclass TEXT,
-                notes TEXT
+                notes TEXT,
+                skill_choices TEXT
             )
             """
         )
@@ -56,6 +57,7 @@ def test_create_build_creates_entry_with_levels(
         "class": "Fighter",
         "subclass": "Arcane Archer",
         "notes": "Ranged build focusing on archery.",
+        "skill_choices": ["Acrobatics", "Stealth", "Perception"],
         "levels": [
             {
                 "level": 1,
@@ -84,6 +86,7 @@ def test_create_build_creates_entry_with_levels(
     assert data["name"] == payload["name"]
     assert data["class"] == payload["class"]
     assert data["notes"] == payload["notes"]
+    assert sorted(data["skill_choices"]) == sorted(payload["skill_choices"])
     assert len(data["levels"]) == 2
 
     first_level = data["levels"][0]
@@ -108,6 +111,7 @@ def test_update_build_replaces_levels(client: TestClient, test_db: Path) -> None
         "class": "Fighter",
         "subclass": "Arcane Archer",
         "notes": "Ranged build focusing on archery.",
+        "skill_choices": ["Acrobatics", "Stealth", "Perception"],
         "levels": [
             {
                 "level": 1,
@@ -148,6 +152,7 @@ def test_update_build_replaces_levels(client: TestClient, test_db: Path) -> None
         "class": "Fighter",
         "subclass": "Arcane Archer",
         "notes": "Updated notes.",
+        "skill_choices": ["Acrobatics", "Stealth", "Insight"],
         "levels": update_levels,
     }
 
@@ -157,6 +162,7 @@ def test_update_build_replaces_levels(client: TestClient, test_db: Path) -> None
     data = response.json()
     assert data["id"] == build_id
     assert data["notes"] == "Updated notes."
+    assert sorted(data["skill_choices"]) == sorted(update_payload["skill_choices"])
     assert len(data["levels"]) == 2
     returned_spells = [level["spells"] for level in data["levels"]]
     assert "Hunter's Mark" in returned_spells
@@ -180,6 +186,7 @@ def test_delete_build_removes_entry(client: TestClient, test_db: Path) -> None:
         "class": "Fighter",
         "subclass": "Arcane Archer",
         "notes": "Ranged build focusing on archery.",
+        "skill_choices": ["Acrobatics", "Stealth", "Perception"],
         "levels": [
             {
                 "level": 1,

--- a/backend/tests/test_builds_error_handling.py
+++ b/backend/tests/test_builds_error_handling.py
@@ -14,6 +14,7 @@ BASE_BUILD_PAYLOAD = {
     "class": "Fighter",
     "subclass": "Arcane Archer",
     "notes": "Test build",
+    "skill_choices": [],
 }
 
 LEVEL_PAYLOAD = {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -592,6 +592,37 @@ button:focus-visible {
   color: var(--color-text-secondary);
 }
 
+.build-form__skill-choices {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.build-form__skill-choices-header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.build-form__skill-options {
+  display: grid;
+  gap: 0.5rem 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.build-form__skill-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.build-form__skill-option input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--color-accent);
+}
+
 .build-form__level-header {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -24,6 +24,7 @@ export interface Build {
   class_name?: string | null
   subclass?: string | null
   notes?: string | null
+  skill_choices: string[]
   levels: BuildLevel[]
 }
 


### PR DESCRIPTION
## Summary
- persist selected class skills for builds, including schema updates and migrations
- replace the textual class skill hint with interactive checkboxes capped at the class limit and hide unused highlights
- style the build form to accommodate the new skill selection area
- restore the committed companion database file to its previous state so the migration can run locally

## Testing
- pytest
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfc05497b4832bb0c49ee4b02b2dad