### PR TITLE
Add spell plan summary field in build form

### DIFF
--- a/frontend/src/components/BuildLibrary.tsx
+++ b/frontend/src/components/BuildLibrary.tsx
@@ -935,6 +935,20 @@ export function BuildLibrary({ builds, races, classes, onCreate, onUpdate, onDel
                               Ces sorts ont été ajoutés manuellement pour ce niveau.
                             </p>
                           ) : null}
+                          <div className="build-form__level-summary">
+                            <label>
+                              Résumé du plan
+                              <textarea
+                                value={plan.summary}
+                                onChange={(event) =>
+                                  updateSpellPlan(index, (currentPlan) => ({
+                                    ...currentPlan,
+                                    summary: event.target.value,
+                                  }))
+                                }
+                              />
+                            </label>
+                          </div>
                           {knownSpellsBefore.length || plan.replacements.length ? (
                             <div className="build-form__spell-replacements">
                               <h6>Remplacements possibles</h6>


### PR DESCRIPTION
## Summary
- add a summary textarea to each spell-planning section of the build form
- wire the new field to update the current level spell plan summary as the user types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d01bb9001c832b8f3a0159c35af1df