### PR TITLE
feat: add aggregated party overview analytics

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -880,6 +880,220 @@ button:focus-visible {
   gap: 1.75rem;
 }
 
+.party-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.party-overview__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: flex-end;
+}
+
+.party-overview__filters label {
+  min-width: 180px;
+}
+
+.party-overview__filters .link {
+  margin-left: auto;
+}
+
+.party-overview__stats-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.party-overview__stat-card {
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(12, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.party-overview__stat-card span {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.party-overview__stat-card strong {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.party-overview__distribution-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.party-overview__distribution-grid h4 {
+  margin-bottom: 0.65rem;
+}
+
+.party-overview__pill-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.party-overview__pill {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 16px;
+  background: rgba(15, 28, 50, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: var(--color-text-primary);
+}
+
+.party-overview__pill--alert {
+  border-color: rgba(244, 114, 182, 0.6);
+  box-shadow: 0 0 0 1px rgba(244, 114, 182, 0.25);
+}
+
+.party-overview__pill-count {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.party-overview__skill-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem;
+}
+
+.party-overview__skill {
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-align: center;
+  border: 1px solid transparent;
+}
+
+.party-overview__skill--covered {
+  background: rgba(56, 189, 248, 0.12);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: var(--color-text-primary);
+}
+
+.party-overview__skill--missing {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.3);
+  color: var(--color-text-secondary);
+}
+
+.party-overview__damage-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.party-overview__damage-grid h5 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.party-overview__badge-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.party-overview__badge {
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--color-text-primary);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.party-overview__badge-list--highlight .party-overview__badge--highlight {
+  background: rgba(244, 211, 94, 0.18);
+  color: var(--color-text-primary);
+  border: 1px solid rgba(244, 211, 94, 0.4);
+}
+
+.party-overview__alerts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.party-overview__alert-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.party-overview__alert {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(12, 23, 42, 0.7);
+  color: var(--color-text-primary);
+}
+
+.party-overview__alert-indicator {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.6);
+}
+
+.party-overview__alert--danger .party-overview__alert-indicator {
+  background: rgba(248, 113, 113, 0.85);
+}
+
+.party-overview__alert--warning .party-overview__alert-indicator {
+  background: rgba(251, 191, 36, 0.85);
+}
+
+.party-overview__alert--info .party-overview__alert-indicator {
+  background: rgba(96, 165, 250, 0.85);
+}
+
+.party-overview__export pre {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 18px;
+  background: rgba(10, 19, 36, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  overflow: auto;
+}
+
 .party-planner__layout {
   display: grid;
   gap: 1.5rem;

--- a/frontend/src/components/PartyOverviewPanel.tsx
+++ b/frontend/src/components/PartyOverviewPanel.tsx
@@ -1,0 +1,340 @@
+import { useMemo, useState } from 'react'
+import type { EquipmentCollections, PartyMember, Spell } from '../types'
+import { computePartyMetrics, type PartyMetrics } from '../utils/party'
+import { Panel } from './Panel'
+
+interface PartyOverviewPanelProps {
+  members: PartyMember[]
+  spells: Spell[]
+  equipment: EquipmentCollections
+  skillsCatalog: string[]
+  roleOptions: string[]
+  actOptions: string[]
+  metrics: PartyMetrics
+}
+
+type AlertSeverity = 'info' | 'warning' | 'danger'
+
+interface AlertEntry {
+  id: string
+  label: string
+  severity: AlertSeverity
+}
+
+const EXPORT_TEMPLATE = {
+  generatedAt: '2025-01-01T12:00:00.000Z',
+  filters: {
+    act: '<string | null>',
+    role: '<string | null>',
+  },
+  metrics: {
+    totalMembers: 0,
+    averageLevel: 0,
+    classDistribution: [{ name: 'Classe', count: 0 }],
+    roleDistribution: [{ name: 'Rôle', count: 0 }],
+    skillsCovered: ['Compétence'],
+    missingSkills: ['Compétence'],
+    damageTypes: {
+      spells: ['Type'],
+      equipment: ['Type'],
+      combined: ['Type'],
+    },
+    alerts: {
+      missingSkills: ['Compétence'],
+      duplicateClasses: ['Classe'],
+      duplicateRoles: ['Rôle'],
+      missingRoles: ['Rôle'],
+    },
+  },
+} as const
+
+export function PartyOverviewPanel({
+  members,
+  spells,
+  equipment,
+  skillsCatalog,
+  roleOptions,
+  actOptions,
+  metrics,
+}: PartyOverviewPanelProps) {
+  const [selectedAct, setSelectedAct] = useState('')
+  const [selectedRole, setSelectedRole] = useState('')
+
+  const availableActs = useMemo(() => {
+    const present = new Set<string>()
+    for (const member of members) {
+      if (member.act) {
+        present.add(member.act)
+      }
+    }
+    const filtered = actOptions.filter((option) => present.has(option))
+    return filtered.length ? filtered : actOptions
+  }, [actOptions, members])
+
+  const filteredMembers = useMemo(
+    () =>
+      members.filter((member) => {
+        if (selectedAct && member.act !== selectedAct) {
+          return false
+        }
+        if (selectedRole && member.role !== selectedRole) {
+          return false
+        }
+        return true
+      }),
+    [members, selectedAct, selectedRole],
+  )
+
+  const filteredMetrics = useMemo(() => {
+    if (!selectedAct && !selectedRole) {
+      return metrics
+    }
+    return computePartyMetrics({
+      members: filteredMembers,
+      spells,
+      equipment,
+      skillsCatalog,
+      roleCatalog: roleOptions,
+    })
+  }, [equipment, filteredMembers, metrics, roleOptions, selectedAct, selectedRole, skillsCatalog, spells])
+
+  const alertEntries: AlertEntry[] = useMemo(() => {
+    if (!filteredMetrics.totalMembers) {
+      return [
+        {
+          id: 'no-members',
+          label: 'Aucun compagnon ne correspond aux filtres sélectionnés.',
+          severity: 'warning',
+        },
+      ]
+    }
+
+    const entries: AlertEntry[] = []
+
+    if (filteredMetrics.alerts.missingSkills.length) {
+      entries.push({
+        id: 'missing-skills',
+        label: `Compétences à couvrir : ${filteredMetrics.alerts.missingSkills.join(', ')}`,
+        severity: 'danger',
+      })
+    }
+
+    if (filteredMetrics.alerts.duplicateClasses.length) {
+      entries.push({
+        id: 'duplicate-classes',
+        label: `Classes en doublon : ${filteredMetrics.alerts.duplicateClasses.join(', ')}`,
+        severity: 'warning',
+      })
+    }
+
+    if (filteredMetrics.alerts.duplicateRoles.length) {
+      entries.push({
+        id: 'duplicate-roles',
+        label: `Rôles en doublon : ${filteredMetrics.alerts.duplicateRoles.join(', ')}`,
+        severity: 'warning',
+      })
+    }
+
+    if (filteredMetrics.alerts.missingRoles.length) {
+      entries.push({
+        id: 'missing-roles',
+        label: `Rôles non représentés : ${filteredMetrics.alerts.missingRoles.join(', ')}`,
+        severity: 'info',
+      })
+    }
+
+    return entries
+  }, [filteredMetrics])
+
+  const exportTemplateJSON = useMemo(() => JSON.stringify(EXPORT_TEMPLATE, null, 2), [])
+
+  const hasFilters = Boolean(selectedAct || selectedRole)
+
+  function resetFilters() {
+    setSelectedAct('')
+    setSelectedRole('')
+  }
+
+  return (
+    <Panel
+      title="Synthèse de l'équipe"
+      subtitle="Visualisez les recoupements et les angles morts de votre groupe"
+      collapsible
+      defaultCollapsed={false}
+    >
+      <div className="party-overview">
+        <div className="party-overview__filters">
+          <label>
+            Acte
+            <select value={selectedAct} onChange={(event) => setSelectedAct(event.target.value)}>
+              <option value="">Tous</option>
+              {availableActs.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Rôle
+            <select value={selectedRole} onChange={(event) => setSelectedRole(event.target.value)}>
+              <option value="">Tous</option>
+              {roleOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+          {hasFilters ? (
+            <button type="button" className="link" onClick={resetFilters}>
+              Réinitialiser
+            </button>
+          ) : null}
+        </div>
+
+        <div className="party-overview__stats-grid">
+          <article className="party-overview__stat-card">
+            <span>Effectif analysé</span>
+            <strong>{filteredMetrics.totalMembers}</strong>
+          </article>
+          <article className="party-overview__stat-card">
+            <span>Niveau moyen</span>
+            <strong>{filteredMetrics.totalMembers ? filteredMetrics.averageLevel.toFixed(2) : '—'}</strong>
+          </article>
+          <article className="party-overview__stat-card">
+            <span>Types de dégâts maîtrisés</span>
+            <strong>{filteredMetrics.damageTypes.combined.length}</strong>
+          </article>
+        </div>
+
+        <div className="party-overview__distribution-grid">
+          <section>
+            <h4>Répartition par classe</h4>
+            <ul className="party-overview__pill-list">
+              {filteredMetrics.classDistribution.map((entry) => {
+                const isAlert = filteredMetrics.alerts.duplicateClasses.includes(entry.name)
+                return (
+                  <li
+                    key={`class-${entry.name}`}
+                    className={`party-overview__pill${isAlert ? ' party-overview__pill--alert' : ''}`}
+                  >
+                    <span>{entry.name}</span>
+                    <span className="party-overview__pill-count">{entry.count}</span>
+                  </li>
+                )
+              })}
+              {!filteredMetrics.classDistribution.length ? (
+                <li className="empty">Aucune classe renseignée.</li>
+              ) : null}
+            </ul>
+          </section>
+
+          <section>
+            <h4>Répartition par rôle</h4>
+            <ul className="party-overview__pill-list">
+              {filteredMetrics.roleDistribution.map((entry) => {
+                const isAlert = filteredMetrics.alerts.duplicateRoles.includes(entry.name)
+                return (
+                  <li
+                    key={`role-${entry.name}`}
+                    className={`party-overview__pill${isAlert ? ' party-overview__pill--alert' : ''}`}
+                  >
+                    <span>{entry.name}</span>
+                    <span className="party-overview__pill-count">{entry.count}</span>
+                  </li>
+                )
+              })}
+              {!filteredMetrics.roleDistribution.length ? (
+                <li className="empty">Aucun rôle défini.</li>
+              ) : null}
+            </ul>
+          </section>
+        </div>
+
+        <section>
+          <h4>Couverture des compétences</h4>
+          <ul className="party-overview__skill-list">
+            {skillsCatalog.map((skill) => {
+              const isCovered = filteredMetrics.skillsCovered.includes(skill)
+              return (
+                <li
+                  key={skill}
+                  className={`party-overview__skill${isCovered ? ' party-overview__skill--covered' : ' party-overview__skill--missing'}`}
+                >
+                  {skill}
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+
+        <section>
+          <h4>Typologies de dégâts connues</h4>
+          <div className="party-overview__damage-grid">
+            <div>
+              <h5>Sorts</h5>
+              <ul className="party-overview__badge-list">
+                {filteredMetrics.damageTypes.spells.map((type) => (
+                  <li key={`spell-damage-${type}`} className="party-overview__badge">
+                    {type}
+                  </li>
+                ))}
+                {!filteredMetrics.damageTypes.spells.length ? <li className="empty">Aucun sort offensif recensé.</li> : null}
+              </ul>
+            </div>
+            <div>
+              <h5>Équipement</h5>
+              <ul className="party-overview__badge-list">
+                {filteredMetrics.damageTypes.equipment.map((type) => (
+                  <li key={`equipment-damage-${type}`} className="party-overview__badge">
+                    {type}
+                  </li>
+                ))}
+                {!filteredMetrics.damageTypes.equipment.length ? (
+                  <li className="empty">Aucune arme assignée avec dégâts identifiés.</li>
+                ) : null}
+              </ul>
+            </div>
+            <div>
+              <h5>Couverture combinée</h5>
+              <ul className="party-overview__badge-list party-overview__badge-list--highlight">
+                {filteredMetrics.damageTypes.combined.map((type) => (
+                  <li key={`combined-damage-${type}`} className="party-overview__badge party-overview__badge--highlight">
+                    {type}
+                  </li>
+                ))}
+                {!filteredMetrics.damageTypes.combined.length ? (
+                  <li className="empty">Aucun type de dégâts détecté.</li>
+                ) : null}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section className="party-overview__alerts">
+          <h4>Alertes prioritaires</h4>
+          <ul className="party-overview__alert-list">
+            {alertEntries.map((alert) => (
+              <li key={alert.id} className={`party-overview__alert party-overview__alert--${alert.severity}`}>
+                <span className="party-overview__alert-indicator" aria-hidden="true" />
+                {alert.label}
+              </li>
+            ))}
+            {!alertEntries.length ? <li className="empty">Aucune alerte à signaler.</li> : null}
+          </ul>
+        </section>
+
+        <section className="party-overview__export">
+          <h4>Format de synthèse exportable</h4>
+          <p>
+            Ce format JSON décrit les données à fournir pour un partage ou un export automatisé de cette synthèse. Les champs
+            <code>filters</code> précisent le contexte (acte, rôle) et <code>metrics</code> encapsule les indicateurs agrégés et les
+            alertes déduites.
+          </p>
+          <pre>{exportTemplateJSON}</pre>
+        </section>
+      </div>
+    </Panel>
+  )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -355,6 +355,8 @@ export interface PartyMember {
   class_name?: string
   subclass?: string
   background?: string
+  act?: string
+  role?: string
   level: number
   buildId?: number
   abilityScores: Record<AbilityScoreKey, number>

--- a/frontend/src/utils/party.ts
+++ b/frontend/src/utils/party.ts
@@ -86,8 +86,8 @@ function normaliseDamageType(value: string | null | undefined): string | null {
 }
 
 function extractDamageTypesFromProperty(property: SpellProperty): string[] {
-  if (!property.property_value) return []
-  const matches = property.property_value.match(DAMAGE_REGEX)
+  if (!property.value) return []
+  const matches = property.value.match(DAMAGE_REGEX)
   if (!matches) return []
   const found = new Set<string>()
   for (const match of matches) {
@@ -103,7 +103,7 @@ function extractDamageTypesFromSpell(spell: Spell): string[] {
   if (!spell.properties?.length) return []
   const damageTypes = new Set<string>()
   for (const property of spell.properties) {
-    if (property.property_name && property.property_name.toLowerCase() === 'damage') {
+    if (property.name && property.name.toLowerCase() === 'damage') {
       for (const type of extractDamageTypesFromProperty(property)) {
         damageTypes.add(type)
       }

--- a/frontend/src/utils/party.ts
+++ b/frontend/src/utils/party.ts
@@ -1,0 +1,258 @@
+import type {
+  EquipmentCollections,
+  PartyMember,
+  Spell,
+  SpellProperty,
+  WeaponItem,
+} from '../types'
+
+export interface PartyMetricsDistributionEntry {
+  name: string
+  count: number
+}
+
+export interface PartyMetricsAlerts {
+  missingSkills: string[]
+  duplicateClasses: string[]
+  duplicateRoles: string[]
+  missingRoles: string[]
+}
+
+export interface PartyMetricsDamageBreakdown {
+  spells: string[]
+  equipment: string[]
+  combined: string[]
+}
+
+export interface PartyMetrics {
+  totalMembers: number
+  averageLevel: number
+  skillsCovered: string[]
+  missingSkills: string[]
+  classDistribution: PartyMetricsDistributionEntry[]
+  roleDistribution: PartyMetricsDistributionEntry[]
+  damageTypes: PartyMetricsDamageBreakdown
+  alerts: PartyMetricsAlerts
+}
+
+export interface ComputePartyMetricsOptions {
+  members: PartyMember[]
+  spells: Spell[]
+  equipment: EquipmentCollections
+  skillsCatalog: string[]
+  roleCatalog: string[]
+}
+
+export const PARTY_ACT_OPTIONS = ['Acte I', 'Acte II', 'Acte III', 'Épilogue'] as const
+
+export const PARTY_ROLE_OPTIONS = [
+  'Avant-garde',
+  'Dégâts',
+  'Soutien',
+  'Contrôle',
+  'Soigneur',
+  'Polyvalent',
+] as const
+
+const DAMAGE_KEYWORDS = [
+  'Acid',
+  'Bludgeoning',
+  'Cold',
+  'Fire',
+  'Force',
+  'Lightning',
+  'Necrotic',
+  'Piercing',
+  'Poison',
+  'Psychic',
+  'Radiant',
+  'Slashing',
+  'Thunder',
+]
+
+const DAMAGE_REGEX = new RegExp(`\\b(${DAMAGE_KEYWORDS.join('|')})\\b`, 'gi')
+
+function normaliseLabel(value: string | null | undefined, fallback: string): string {
+  if (!value) return fallback
+  const trimmed = value.trim()
+  return trimmed ? trimmed : fallback
+}
+
+function normaliseDamageType(value: string | null | undefined): string | null {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1).toLowerCase()
+}
+
+function extractDamageTypesFromProperty(property: SpellProperty): string[] {
+  if (!property.property_value) return []
+  const matches = property.property_value.match(DAMAGE_REGEX)
+  if (!matches) return []
+  const found = new Set<string>()
+  for (const match of matches) {
+    const normalised = normaliseDamageType(match)
+    if (normalised) {
+      found.add(normalised)
+    }
+  }
+  return [...found]
+}
+
+function extractDamageTypesFromSpell(spell: Spell): string[] {
+  if (!spell.properties?.length) return []
+  const damageTypes = new Set<string>()
+  for (const property of spell.properties) {
+    if (property.property_name && property.property_name.toLowerCase() === 'damage') {
+      for (const type of extractDamageTypesFromProperty(property)) {
+        damageTypes.add(type)
+      }
+    }
+  }
+  return [...damageTypes]
+}
+
+function extractDamageTypesFromWeapon(weapon: WeaponItem | undefined): string[] {
+  if (!weapon?.damages?.length) return []
+  const damageTypes = new Set<string>()
+  for (const damage of weapon.damages) {
+    const normalised = normaliseDamageType(damage.damage_type)
+    if (normalised) {
+      damageTypes.add(normalised)
+    }
+  }
+  return [...damageTypes]
+}
+
+export function computePartyMetrics({
+  members,
+  spells,
+  equipment,
+  skillsCatalog,
+  roleCatalog,
+}: ComputePartyMetricsOptions): PartyMetrics {
+  if (!members.length) {
+    return {
+      totalMembers: 0,
+      averageLevel: 0,
+      skillsCovered: [],
+      missingSkills: [...skillsCatalog],
+      classDistribution: [],
+      roleDistribution: [],
+      damageTypes: { spells: [], equipment: [], combined: [] },
+      alerts: {
+        missingSkills: [...skillsCatalog],
+        duplicateClasses: [],
+        duplicateRoles: [],
+        missingRoles: [...roleCatalog],
+      },
+    }
+  }
+
+  const spellMap = new Map<string, Spell>()
+  for (const spell of spells) {
+    spellMap.set(spell.name, spell)
+  }
+
+  const weaponMap = new Map<string, WeaponItem>()
+  for (const weapon of equipment.weapons) {
+    weaponMap.set(weapon.name, weapon)
+  }
+
+  const skillSet = new Set<string>()
+  const classCounts = new Map<string, number>()
+  const roleCounts = new Map<string, number>()
+  const spellDamageTypes = new Set<string>()
+  const equipmentDamageTypes = new Set<string>()
+
+  let levelTotal = 0
+
+  for (const member of members) {
+    levelTotal += member.level
+
+    for (const skill of member.skills) {
+      skillSet.add(skill)
+    }
+
+    const classLabel = normaliseLabel(member.class_name, 'Classe non assignée')
+    classCounts.set(classLabel, (classCounts.get(classLabel) ?? 0) + 1)
+
+    const roleLabel = normaliseLabel(member.role, 'Rôle non défini')
+    roleCounts.set(roleLabel, (roleCounts.get(roleLabel) ?? 0) + 1)
+
+    for (const spellName of member.spells) {
+      const spell = spellMap.get(spellName)
+      if (!spell) continue
+      for (const type of extractDamageTypesFromSpell(spell)) {
+        spellDamageTypes.add(type)
+      }
+    }
+
+    const equipmentSelection = member.equipment ?? {}
+    const weaponSlots: Array<'mainHand' | 'offHand' | 'ranged'> = ['mainHand', 'offHand', 'ranged']
+    for (const slot of weaponSlots) {
+      const weaponName = equipmentSelection[slot]
+      if (!weaponName) continue
+      const weapon = weaponMap.get(weaponName)
+      if (!weapon) continue
+      for (const type of extractDamageTypesFromWeapon(weapon)) {
+        equipmentDamageTypes.add(type)
+      }
+    }
+  }
+
+  const totalMembers = members.length
+  const averageLevel = totalMembers ? Number((levelTotal / totalMembers).toFixed(2)) : 0
+
+  const skillsCovered = [...skillSet].sort((a, b) => a.localeCompare(b, 'fr'))
+  const missingSkills = skillsCatalog.filter((skill) => !skillSet.has(skill))
+
+  const classDistribution = [...classCounts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => {
+      if (b.count === a.count) {
+        return a.name.localeCompare(b.name, 'fr')
+      }
+      return b.count - a.count
+    })
+
+  const roleDistribution = [...roleCounts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => {
+      if (b.count === a.count) {
+        return a.name.localeCompare(b.name, 'fr')
+      }
+      return b.count - a.count
+    })
+
+  const damageTypes = {
+    spells: [...spellDamageTypes].sort((a, b) => a.localeCompare(b, 'fr')),
+    equipment: [...equipmentDamageTypes].sort((a, b) => a.localeCompare(b, 'fr')),
+  }
+  const combinedDamageTypes = new Set([...damageTypes.spells, ...damageTypes.equipment])
+
+  const alerts: PartyMetricsAlerts = {
+    missingSkills,
+    duplicateClasses: classDistribution
+      .filter((entry) => entry.count > 1 && entry.name !== 'Classe non assignée')
+      .map((entry) => entry.name),
+    duplicateRoles: roleDistribution
+      .filter((entry) => entry.count > 1 && entry.name !== 'Rôle non défini')
+      .map((entry) => entry.name),
+    missingRoles: roleCatalog.filter((role) => (roleCounts.get(role) ?? 0) === 0),
+  }
+
+  return {
+    totalMembers,
+    averageLevel,
+    skillsCovered,
+    missingSkills,
+    classDistribution,
+    roleDistribution,
+    damageTypes: {
+      ...damageTypes,
+      combined: [...combinedDamageTypes].sort((a, b) => a.localeCompare(b, 'fr')),
+    },
+    alerts,
+  }
+}


### PR DESCRIPTION
## Summary
- compute party-wide metrics from stored members including skills, classes, roles, and damage types
- extend party member form with act and role metadata and surface a PartyOverviewPanel with filters and alerts
- add reusable utilities for party aggregation and document the export template for future sharing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d02506e8b4832b9c797d370c6eba93